### PR TITLE
Update vulnerable dependencies / Actualizar dependencias vulnerables

### DIFF
--- a/apps/sheets/native/xlsx-engine/Cargo.lock
+++ b/apps/sheets/native/xlsx-engine/Cargo.lock
@@ -178,7 +178,7 @@ dependencies = [
  "encoding_rs",
  "fast-float2",
  "log",
- "quick-xml 0.41.0",
+ "quick-xml",
  "serde",
  "zip 8.6.0",
 ]
@@ -729,15 +729,6 @@ dependencies = [
 
 [[package]]
 name = "quick-xml"
-version = "0.38.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b66c2058c55a409d601666cffe35f04333cf1013010882cec174a7467cd4e21c"
-dependencies = [
- "memchr",
-]
-
-[[package]]
-name = "quick-xml"
 version = "0.41.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e660451e55124f798a69a5af3f49ccfbefbd41910eefd25caf2393e1f3473ec1"
@@ -1189,7 +1180,7 @@ dependencies = [
  "base64",
  "calamine",
  "ironcalc",
- "quick-xml 0.38.4",
+ "quick-xml",
  "roxmltree 0.21.1",
  "serde",
  "serde_json",

--- a/apps/sheets/native/xlsx-engine/Cargo.toml
+++ b/apps/sheets/native/xlsx-engine/Cargo.toml
@@ -9,7 +9,7 @@ publish = false
 base64 = "0.22.1"
 calamine = "0.36.0"
 ironcalc = "0.7.1"
-quick-xml = "0.38"
+quick-xml = "0.41"
 roxmltree = "0.21.1"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/apps/sheets/native/xlsx-engine/src/lib.rs
+++ b/apps/sheets/native/xlsx-engine/src/lib.rs
@@ -8,7 +8,7 @@ use std::thread::{self, JoinHandle};
 use std::time::Duration;
 
 use quick_xml::events::{BytesStart, Event};
-use quick_xml::Reader;
+use quick_xml::{Reader, XmlVersion};
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 use zip::ZipArchive;
@@ -2426,7 +2426,7 @@ fn attribute_value<R: std::io::BufRead>(
         if attribute.key.local_name().as_ref() == name {
             return Ok(Some(
                 attribute
-                    .decode_and_unescape_value(reader.decoder())?
+                    .decoded_and_normalized_value(XmlVersion::Implicit1_0, reader.decoder())?
                     .into_owned(),
             ));
         }

--- a/package-lock.json
+++ b/package-lock.json
@@ -7561,9 +7561,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.4.tgz",
-      "integrity": "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
+      "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
       "dev": true,
       "funding": [
         {
@@ -8558,9 +8558,9 @@
       }
     },
     "node_modules/jsdom/node_modules/undici": {
-      "version": "7.28.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-7.28.0.tgz",
-      "integrity": "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==",
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.29.0.tgz",
+      "integrity": "sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -9591,9 +9591,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.20",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.20.tgz",
-      "integrity": "sha512-lW616l85ucIQL+FocMmL7pQFPqBmwejrCMg+iPxyImlrANNJG9NHq/RkyCZopDhd8C3LA03PHRJDjkbGu8vvug==",
+      "version": "8.5.25",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.25.tgz",
+      "integrity": "sha512-DTPx3RWSSnWyzLxQnlH0rJP+EW5ekl16ZU4/psbIhA0e53kJfdgaN5vKM+xP7yJtXVu+nfdVFmlgFDEKAe4Pyw==",
       "dev": true,
       "funding": [
         {
@@ -11083,7 +11083,6 @@
       "os": [
         "aix"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -11101,7 +11100,6 @@
       "os": [
         "android"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -11119,7 +11117,6 @@
       "os": [
         "android"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -11137,7 +11134,6 @@
       "os": [
         "android"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -11155,7 +11151,6 @@
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -11173,7 +11168,6 @@
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -11191,7 +11185,6 @@
       "os": [
         "freebsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -11209,7 +11202,6 @@
       "os": [
         "freebsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -11227,7 +11219,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -11245,7 +11236,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -11263,7 +11253,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -11281,7 +11270,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -11299,7 +11287,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -11317,7 +11304,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -11335,7 +11321,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -11353,7 +11338,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -11371,7 +11355,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -11389,7 +11372,6 @@
       "os": [
         "netbsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -11407,7 +11389,6 @@
       "os": [
         "netbsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -11425,7 +11406,6 @@
       "os": [
         "openbsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -11443,7 +11423,6 @@
       "os": [
         "openbsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -11461,7 +11440,6 @@
       "os": [
         "openharmony"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -11479,7 +11457,6 @@
       "os": [
         "sunos"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -11497,7 +11474,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -11515,7 +11491,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -11533,7 +11508,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -11646,9 +11620,9 @@
       }
     },
     "node_modules/undici": {
-      "version": "6.27.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-6.27.0.tgz",
-      "integrity": "sha512-YmfV3YnEDzXRC5lZ2jWtWWHKGUm1zIt8AhesR1tens+HTNv+YZlN/dp6G727LOvMJ8xjP9Be7Y2Sdr96LDm+pg==",
+      "version": "6.28.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.28.0.tgz",
+      "integrity": "sha512-LIY910g9TI13YS95lrMFrs8Rm/u/irgHeTWoKCoteeJ04CUJ92eEfj0rVn+7VKMPBpUPiUoBKfhNyLI23EE/KA==",
       "dev": true,
       "license": "MIT",
       "engines": {


### PR DESCRIPTION
## English

### What changed

- Updated vulnerable npm packages in `package-lock.json`.
- Updated `quick-xml` from 0.38 to 0.41.
- Updated one Rust API call for `quick-xml` 0.41 while keeping XML 1.0 behavior.

### Why

The lock files used package versions listed in npm and Rust security advisories. New installations should use patched versions.

### Impact

The project now installs versions with no known findings in the npm and OSV scans. Application behavior is unchanged.

### Checks

- `npm audit`: 0 known vulnerabilities.
- OSV scan: 0 findings in 144 Cargo packages.
- Rust sidecar: 44 tests passed and the release build passed.
- Full `npm test`: 891 tests passed; 3 Sheets tests failed on Windows with `EPERM` during `fsync`.
- `format:check` could not start Prettier on Windows: `spawnSync ... prettier.cmd EINVAL`.

## Español

### Qué cambió

- Actualicé paquetes vulnerables de npm en `package-lock.json`.
- Actualicé `quick-xml` de 0.38 a 0.41.
- Actualicé una llamada de Rust para `quick-xml` 0.41 y mantuve el comportamiento de XML 1.0.

### Por qué

Los archivos de bloqueo usaban versiones incluidas en avisos de seguridad de npm y Rust. Las nuevas instalaciones deben usar versiones corregidas.

### Impacto

El proyecto ahora instala versiones sin hallazgos conocidos en los análisis de npm y OSV. El comportamiento de la aplicación no cambia.

### Comprobaciones

- `npm audit`: 0 vulnerabilidades conocidas.
- Análisis de OSV: 0 hallazgos en 144 paquetes de Cargo.
- Sidecar de Rust: 44 pruebas aprobadas y compilación release correcta.
- `npm test` completo: 891 pruebas aprobadas; 3 pruebas de Sheets fallaron en Windows con `EPERM` durante `fsync`.
- `format:check` no pudo iniciar Prettier en Windows: `spawnSync ... prettier.cmd EINVAL`.
