### PR TITLE
docs: propose community roadmap (AI trust UX, MCP surface, collaboration)

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -48,7 +48,7 @@ Três princípios que decorrem do que o código já faz bem:
 
 - **Local-first**: o arquivo é a fonte da verdade; sync é uma camada, não um
   requisito. Nada de conta obrigatória.
-- **Propor antes de mutar**: toda edição de agente deve ser um *diff revisável*
+- **Propor antes de mutar**: toda edição de agente deve ser um _diff revisável_
   (o modelo do sheets), com aceitar/rejeitar granular e rollback.
 - **Um protocolo para todos os autores**: humano na UI, Hermes no painel, e
   agentes externos via MCP falam com o documento pela mesma superfície de
@@ -127,14 +127,14 @@ Objetivo: multi-usuário local-first, com agentes como participantes.
 
 ## Como a comunidade pode ajudar agora
 
-| Perfil | Por onde começar |
-|---|---|
-| Primeiro PR | TODOs mapeados (slicers, pivot, z-order, IME), testes de `agent-core` |
-| TypeScript/React | Unificação do proposed-change (Fase 1), paridade do app PDF |
-| Interessado em agentes | MCP server embutido, skills Hermes, plugins runtime |
-| Rust | Sidecar xlsx (pivot externo, performance) |
-| Distributed systems | RFC da camada CRDT (Fase 3) — abra uma issue de design antes de codar |
-| Docs/i18n | Guias de setup do gateway Hermes, traduções em `packages/i18n` |
+| Perfil                 | Por onde começar                                                      |
+| ---------------------- | --------------------------------------------------------------------- |
+| Primeiro PR            | TODOs mapeados (slicers, pivot, z-order, IME), testes de `agent-core` |
+| TypeScript/React       | Unificação do proposed-change (Fase 1), paridade do app PDF           |
+| Interessado em agentes | MCP server embutido, skills Hermes, plugins runtime                   |
+| Rust                   | Sidecar xlsx (pivot externo, performance)                             |
+| Distributed systems    | RFC da camada CRDT (Fase 3) — abra uma issue de design antes de codar |
+| Docs/i18n              | Guias de setup do gateway Hermes, traduções em `packages/i18n`        |
 
 Regras de contribuição em [CONTRIBUTING.md](../CONTRIBUTING.md). Para
 mudanças arquiteturais (Fases 2–3), abra primeiro uma issue `rfc` descrevendo

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1,0 +1,141 @@
+# Roadmap HermesOffice — o office do futuro, colaborativo entre humanos e agentes
+
+Este documento propõe uma direção de evolução para a comunidade. Ele parte de
+uma leitura honesta do código de hoje: o que já é forte, o que falta, e em que
+ordem atacar. Nada aqui é promessa — é um convite a contribuir. Discussões e
+ajustes: abra uma issue com o label `roadmap`.
+
+## Onde estamos (diagnóstico)
+
+**Forças reais do código atual**
+
+- Engines de formato maduros e muito bem testados (docx round-trip byte-preserving,
+  pptx engine própria, xlsx via sidecar Rust). Essa é a fundação que quase nenhum
+  projeto open-source tem.
+- `packages/agent-core` enxuto e sólido: loop ReAct genérico com compactação de
+  contexto, retry de tool-input, cancelamento, snapshots e sessão persistente
+  (`X-Hermes-Session-Id` por documento já entregue).
+- IA nativa local via gateway Hermes (OpenAI-compatible, sem conta, sem nuvem).
+
+**Lacunas estruturais**
+
+1. **UX de confiança da IA é inconsistente entre apps.** Sheets tem o melhor
+   modelo (`propose_operations` → preview de diff → aplicação atômica); docs e
+   slides usam snapshot + rollback pós-fato; **pdf não tem nenhum dos dois** e
+   nem sequer força o provider `hermes` como os outros três apps.
+2. **Colaboração é inexistente.** Zero CRDT/OT/sync/presence. Comentários e
+   track-changes existem, mas são features OOXML single-user. O
+   `project-store` local já espelha um modelo de projeto "de nuvem" — o gancho
+   existe, a nuvem não.
+3. **Extensibilidade não formalizada.** `AgentSkill` + `composeSkills()` é um
+   sistema de plugins de facto, mas só em compile-time. Sem MCP host, sem
+   scripting de usuário (fora a DSL interna de slides), sem API de automação.
+4. **Integração Hermes inacabada** (ver `docs/hermes-integration.md`):
+   health-check do gateway, launcher, e tools de documento expostas ao agente.
+5. **Cobertura de testes desbalanceada:** engines com 50–76 arquivos de teste
+   cada; `agent-core` (o coração da IA) com 2; `slides-skill.ts` (3.325 linhas,
+   33 tools) proporcionalmente pouco coberto; só 3 specs E2E.
+
+## Visão
+
+> Um office onde humanos e agentes editam os **mesmos documentos, pelo mesmo
+> protocolo, com o mesmo modelo de permissão e revisão** — local-first,
+> privado por padrão, e colaborativo por design. O agente não é um chat ao
+> lado do documento: é um participante do documento, com presença, autoria,
+> propostas revisáveis e histórico.
+
+Três princípios que decorrem do que o código já faz bem:
+
+- **Local-first**: o arquivo é a fonte da verdade; sync é uma camada, não um
+  requisito. Nada de conta obrigatória.
+- **Propor antes de mutar**: toda edição de agente deve ser um *diff revisável*
+  (o modelo do sheets), com aceitar/rejeitar granular e rollback.
+- **Um protocolo para todos os autores**: humano na UI, Hermes no painel, e
+  agentes externos via MCP falam com o documento pela mesma superfície de
+  tools/ops — autoria e auditoria idênticas.
+
+## Fase 1 — Consolidar a fundação de IA (curto prazo, ~1 release)
+
+Objetivo: paridade e confiança. Tudo aqui é incremental sobre código existente.
+
+- **Contrato unificado de "proposed change" no `agent-core`.** Generalizar o
+  `ChangePlan` do sheets: `ToolExecution` ganha um modo `proposed`, o loop
+  ganha ciclo propose → review → apply/reject, e cada app implementa o render
+  do diff. Docs e slides migram; pdf adota.
+- **Nivelar o app PDF**: forçar provider `hermes` como os demais, adicionar
+  `files-skill`/`web_search`, snapshots + rollback, e primeiras tools de
+  edição de conteúdo (texto de anotações, stamps, montagem de páginas).
+- **Fechar o roadmap Hermes pendente**: health-check `/health` antes do stream
+  com erro amigável "gateway offline"; launcher opcional que sobe o gateway;
+  documentar setup em 1 comando.
+- **Dívida de teste crítica**: suíte dedicada para `agent-core` (compactação,
+  retry, cancelamento, snapshot) e testes de contrato para as 33 tools de
+  slides; +E2E cobrindo um fluxo de IA por app.
+- Quick wins de formato já mapeados nos TODOs: persistência OOXML de slicers,
+  pivot com fontes externas, z-order em picture edit, IME sobre seleção.
+
+## Fase 2 — Documento como superfície de agentes (médio prazo)
+
+Objetivo: transformar a integração "arquivo + file-watcher" de hoje num
+protocolo de primeira classe.
+
+- **MCP server embutido por app** (`hermesoffice-docs-mcp` etc.): expor as
+  mesmas tools do painel de IA (`read_blocks`, `replace_blocks`,
+  `propose_operations`, tools de slides/pdf) a qualquer agente MCP — Hermes,
+  Claude Code, ou o que a comunidade plugar. Toda mutação externa entra pelo
+  mesmo pipeline de proposed-change/track-changes.
+- **Skills de documento no lado do Hermes**: pacote de skills publicado para o
+  gateway consumir, fechando o item aberto do `hermes-integration.md`.
+- **Autoria de agente**: comentários e revisions OOXML assinados com a
+  identidade do agente ("Hermes propôs, Gustavo aceitou") — a base de
+  auditoria antes de qualquer colaboração em rede.
+- **API de automação/headless**: CLI sobre os engines (converter, aplicar
+  patch, extrair) — os engines já são TS puro sem Electron; é empacotamento,
+  não pesquisa.
+- **Sistema de plugins runtime**: evoluir `AgentSkill` de compile-time para
+  carregamento dinâmico com manifest e permissões declaradas (quais tools,
+  quais escopos), reutilizando a validação Zod já existente no IPC.
+
+## Fase 3 — Colaboração humano + agente (longo prazo)
+
+Objetivo: multi-usuário local-first, com agentes como participantes.
+
+- **Camada CRDT opcional** (Yjs ou Automerge) por cima do modelo de blocos:
+  o docx segue sendo a verdade em disco; o CRDT é o transporte de sessão.
+  Começar por docs (modelo de blocos com âncoras `docxIndex` já é
+  patch-friendly); sheets pode avaliar o ecossistema Univer.
+- **Presence & awareness**: cursores, seleções — e o agente aparece como um
+  participante com cursor próprio enquanto trabalha.
+- **Sync server open-source de referência** (candidato natural ao diretório
+  `ee/` para variantes enterprise: SSO, retenção, deploy privado), mantendo o
+  produto 100% funcional offline e peer-to-peer em rede local.
+- **Sessões de trabalho compartilhadas com agentes**: vários humanos + um
+  Hermes na mesma sessão, com fila de propostas e permissões por participante.
+
+## Fase 4 — O office do futuro (exploratório)
+
+- **Documentos vivos**: blocos ligados a fontes (uma tabela do sheets embutida
+  no docs, um range que alimenta um gráfico no slides) com recomputação
+  reativa.
+- **Agente proativo com consentimento**: Hermes observa o documento (opt-in) e
+  sugere — "esses números não batem com a planilha anexa" — sempre como
+  proposta, nunca como mutação.
+- **Geração cruzada**: "transforme este relatório em deck" como pipeline entre
+  engines, não como prompt gigante.
+- **Voz e reunião**: ditar edições, transcrever reunião direto num docs com o
+  agente estruturando em tempo real.
+
+## Como a comunidade pode ajudar agora
+
+| Perfil | Por onde começar |
+|---|---|
+| Primeiro PR | TODOs mapeados (slicers, pivot, z-order, IME), testes de `agent-core` |
+| TypeScript/React | Unificação do proposed-change (Fase 1), paridade do app PDF |
+| Interessado em agentes | MCP server embutido, skills Hermes, plugins runtime |
+| Rust | Sidecar xlsx (pivot externo, performance) |
+| Distributed systems | RFC da camada CRDT (Fase 3) — abra uma issue de design antes de codar |
+| Docs/i18n | Guias de setup do gateway Hermes, traduções em `packages/i18n` |
+
+Regras de contribuição em [CONTRIBUTING.md](../CONTRIBUTING.md). Para
+mudanças arquiteturais (Fases 2–3), abra primeiro uma issue `rfc` descrevendo
+o design — merge de código estrutural sem RFC prévia tende a ser devolvido.

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1,141 +1,142 @@
-# Roadmap HermesOffice — o office do futuro, colaborativo entre humanos e agentes
+# HermesOffice Roadmap — the office of the future, collaborative between humans and agents
 
-Este documento propõe uma direção de evolução para a comunidade. Ele parte de
-uma leitura honesta do código de hoje: o que já é forte, o que falta, e em que
-ordem atacar. Nada aqui é promessa — é um convite a contribuir. Discussões e
-ajustes: abra uma issue com o label `roadmap`.
+This document proposes a direction of evolution for the community. It starts
+from an honest reading of today's code: what is already strong, what is
+missing, and in what order to attack it. Nothing here is a promise — it is an
+invitation to contribute. Discussion and adjustments: open an issue with the
+`roadmap` label.
 
-## Onde estamos (diagnóstico)
+## Where we are (diagnosis)
 
-**Forças reais do código atual**
+**Real strengths of the current code**
 
-- Engines de formato maduros e muito bem testados (docx round-trip byte-preserving,
-  pptx engine própria, xlsx via sidecar Rust). Essa é a fundação que quase nenhum
-  projeto open-source tem.
-- `packages/agent-core` enxuto e sólido: loop ReAct genérico com compactação de
-  contexto, retry de tool-input, cancelamento, snapshots e sessão persistente
-  (`X-Hermes-Session-Id` por documento já entregue).
-- IA nativa local via gateway Hermes (OpenAI-compatible, sem conta, sem nuvem).
+- Mature, very well tested format engines (byte-preserving docx round-trip,
+  in-house pptx engine, xlsx via Rust sidecar). This is a foundation almost no
+  open-source project has.
+- A lean, solid `packages/agent-core`: a generic ReAct loop with context
+  compaction, tool-input retry, cancellation, snapshots and persistent
+  sessions (per-document `X-Hermes-Session-Id` already shipped).
+- Native local AI via the Hermes gateway (OpenAI-compatible, no account, no
+  cloud).
 
-**Lacunas estruturais**
+**Structural gaps**
 
-1. **UX de confiança da IA é inconsistente entre apps.** Sheets tem o melhor
-   modelo (`propose_operations` → preview de diff → aplicação atômica); docs e
-   slides usam snapshot + rollback pós-fato; **pdf não tem nenhum dos dois** e
-   nem sequer força o provider `hermes` como os outros três apps.
-2. **Colaboração é inexistente.** Zero CRDT/OT/sync/presence. Comentários e
-   track-changes existem, mas são features OOXML single-user. O
-   `project-store` local já espelha um modelo de projeto "de nuvem" — o gancho
-   existe, a nuvem não.
-3. **Extensibilidade não formalizada.** `AgentSkill` + `composeSkills()` é um
-   sistema de plugins de facto, mas só em compile-time. Sem MCP host, sem
-   scripting de usuário (fora a DSL interna de slides), sem API de automação.
-4. **Integração Hermes inacabada** (ver `docs/hermes-integration.md`):
-   health-check do gateway, launcher, e tools de documento expostas ao agente.
-5. **Cobertura de testes desbalanceada:** engines com 50–76 arquivos de teste
-   cada; `agent-core` (o coração da IA) com 2; `slides-skill.ts` (3.325 linhas,
-   33 tools) proporcionalmente pouco coberto; só 3 specs E2E.
+1. **AI trust UX is inconsistent across apps.** Sheets has the best model
+   (`propose_operations` → diff preview → atomic apply); docs and slides use
+   after-the-fact snapshot + rollback; **pdf has neither** and does not even
+   force the `hermes` provider like the other three apps.
+2. **Collaboration is nonexistent.** Zero CRDT/OT/sync/presence. Comments and
+   track-changes exist, but they are single-user OOXML features. The local
+   `project-store` already mirrors a "cloud" project model — the hook exists,
+   the cloud does not.
+3. **Extensibility is not formalized.** `AgentSkill` + `composeSkills()` is a
+   de facto plugin system, but compile-time only. No MCP host, no user
+   scripting (beyond the internal slides DSL), no automation API.
+4. **Hermes integration is unfinished** (see `docs/hermes-integration.md`):
+   gateway health check, launcher, and document tools exposed to the agent.
+5. **Unbalanced test coverage:** engines have 50–76 test files each;
+   `agent-core` (the heart of the AI) has 2; `slides-skill.ts` (3,325 lines,
+   33 tools) is proportionally under-covered; only 3 E2E specs.
 
-## Visão
+## Vision
 
-> Um office onde humanos e agentes editam os **mesmos documentos, pelo mesmo
-> protocolo, com o mesmo modelo de permissão e revisão** — local-first,
-> privado por padrão, e colaborativo por design. O agente não é um chat ao
-> lado do documento: é um participante do documento, com presença, autoria,
-> propostas revisáveis e histórico.
+> An office where humans and agents edit the **same documents, through the
+> same protocol, with the same permission and review model** — local-first,
+> private by default, and collaborative by design. The agent is not a chat
+> next to the document: it is a participant in the document, with presence,
+> authorship, reviewable proposals and history.
 
-Três princípios que decorrem do que o código já faz bem:
+Three principles that follow from what the code already does well:
 
-- **Local-first**: o arquivo é a fonte da verdade; sync é uma camada, não um
-  requisito. Nada de conta obrigatória.
-- **Propor antes de mutar**: toda edição de agente deve ser um _diff revisável_
-  (o modelo do sheets), com aceitar/rejeitar granular e rollback.
-- **Um protocolo para todos os autores**: humano na UI, Hermes no painel, e
-  agentes externos via MCP falam com o documento pela mesma superfície de
-  tools/ops — autoria e auditoria idênticas.
+- **Local-first**: the file is the source of truth; sync is a layer, not a
+  requirement. No mandatory account.
+- **Propose before mutating**: every agent edit should be a _reviewable diff_
+  (the sheets model), with granular accept/reject and rollback.
+- **One protocol for all authors**: a human in the UI, Hermes in the panel,
+  and external agents via MCP all talk to the document through the same
+  tools/ops surface — identical authorship and auditability.
 
-## Fase 1 — Consolidar a fundação de IA (curto prazo, ~1 release)
+## Phase 1 — Consolidate the AI foundation (short term, ~1 release)
 
-Objetivo: paridade e confiança. Tudo aqui é incremental sobre código existente.
+Goal: parity and trust. Everything here is incremental over existing code.
 
-- **Contrato unificado de "proposed change" no `agent-core`.** Generalizar o
-  `ChangePlan` do sheets: `ToolExecution` ganha um modo `proposed`, o loop
-  ganha ciclo propose → review → apply/reject, e cada app implementa o render
-  do diff. Docs e slides migram; pdf adota.
-- **Nivelar o app PDF**: forçar provider `hermes` como os demais, adicionar
-  `files-skill`/`web_search`, snapshots + rollback, e primeiras tools de
-  edição de conteúdo (texto de anotações, stamps, montagem de páginas).
-- **Fechar o roadmap Hermes pendente**: health-check `/health` antes do stream
-  com erro amigável "gateway offline"; launcher opcional que sobe o gateway;
-  documentar setup em 1 comando.
-- **Dívida de teste crítica**: suíte dedicada para `agent-core` (compactação,
-  retry, cancelamento, snapshot) e testes de contrato para as 33 tools de
-  slides; +E2E cobrindo um fluxo de IA por app.
-- Quick wins de formato já mapeados nos TODOs: persistência OOXML de slicers,
-  pivot com fontes externas, z-order em picture edit, IME sobre seleção.
+- **Unified "proposed change" contract in `agent-core`.** Generalize the
+  sheets `ChangePlan`: `ToolExecution` gains a `proposed` mode, the loop gains
+  a propose → review → apply/reject cycle, and each app implements the diff
+  rendering. Docs and slides migrate; pdf adopts.
+- **Bring the PDF app up to par**: force the `hermes` provider like the
+  others, add `files-skill`/`web_search`, snapshots + rollback, and first
+  content-editing tools (annotation text, stamps, page assembly).
+- **Close the pending Hermes roadmap**: `/health` check before streaming with
+  a friendly "gateway offline" error; optional launcher that starts the
+  gateway; document one-command setup.
+- **Critical test debt**: a dedicated suite for `agent-core` (compaction,
+  retry, cancellation, snapshot) and contract tests for the 33 slides tools;
+  plus one AI-flow E2E per app.
+- Format quick wins already mapped in TODOs: OOXML slicer persistence, pivots
+  with external sources, z-order in picture edit, IME over selection.
 
-## Fase 2 — Documento como superfície de agentes (médio prazo)
+## Phase 2 — The document as an agent surface (mid term)
 
-Objetivo: transformar a integração "arquivo + file-watcher" de hoje num
-protocolo de primeira classe.
+Goal: turn today's "file + file-watcher" integration into a first-class
+protocol.
 
-- **MCP server embutido por app** (`hermesoffice-docs-mcp` etc.): expor as
-  mesmas tools do painel de IA (`read_blocks`, `replace_blocks`,
-  `propose_operations`, tools de slides/pdf) a qualquer agente MCP — Hermes,
-  Claude Code, ou o que a comunidade plugar. Toda mutação externa entra pelo
-  mesmo pipeline de proposed-change/track-changes.
-- **Skills de documento no lado do Hermes**: pacote de skills publicado para o
-  gateway consumir, fechando o item aberto do `hermes-integration.md`.
-- **Autoria de agente**: comentários e revisions OOXML assinados com a
-  identidade do agente ("Hermes propôs, Gustavo aceitou") — a base de
-  auditoria antes de qualquer colaboração em rede.
-- **API de automação/headless**: CLI sobre os engines (converter, aplicar
-  patch, extrair) — os engines já são TS puro sem Electron; é empacotamento,
-  não pesquisa.
-- **Sistema de plugins runtime**: evoluir `AgentSkill` de compile-time para
-  carregamento dinâmico com manifest e permissões declaradas (quais tools,
-  quais escopos), reutilizando a validação Zod já existente no IPC.
+- **Embedded MCP server per app** (`hermesoffice-docs-mcp` etc.): expose the
+  same tools as the AI panel (`read_blocks`, `replace_blocks`,
+  `propose_operations`, slides/pdf tools) to any MCP agent — Hermes, Claude
+  Code, or whatever the community plugs in. Every external mutation goes
+  through the same proposed-change/track-changes pipeline.
+- **Document skills on the Hermes side**: a published skills package for the
+  gateway to consume, closing the open item in `hermes-integration.md`.
+- **Agent authorship**: OOXML comments and revisions signed with the agent's
+  identity ("Hermes proposed, you accepted") — the audit base before any
+  networked collaboration.
+- **Automation/headless API**: a CLI over the engines (convert, apply patch,
+  extract) — the engines are already pure TS with no Electron; this is
+  packaging, not research.
+- **Runtime plugin system**: evolve `AgentSkill` from compile-time to dynamic
+  loading with a manifest and declared permissions (which tools, which
+  scopes), reusing the Zod validation already present in the IPC layer.
 
-## Fase 3 — Colaboração humano + agente (longo prazo)
+## Phase 3 — Human + agent collaboration (long term)
 
-Objetivo: multi-usuário local-first, com agentes como participantes.
+Goal: local-first multi-user, with agents as participants.
 
-- **Camada CRDT opcional** (Yjs ou Automerge) por cima do modelo de blocos:
-  o docx segue sendo a verdade em disco; o CRDT é o transporte de sessão.
-  Começar por docs (modelo de blocos com âncoras `docxIndex` já é
-  patch-friendly); sheets pode avaliar o ecossistema Univer.
-- **Presence & awareness**: cursores, seleções — e o agente aparece como um
-  participante com cursor próprio enquanto trabalha.
-- **Sync server open-source de referência** (candidato natural ao diretório
-  `ee/` para variantes enterprise: SSO, retenção, deploy privado), mantendo o
-  produto 100% funcional offline e peer-to-peer em rede local.
-- **Sessões de trabalho compartilhadas com agentes**: vários humanos + um
-  Hermes na mesma sessão, com fila de propostas e permissões por participante.
+- **Optional CRDT layer** (Yjs or Automerge) on top of the block model: the
+  docx remains the truth on disk; the CRDT is the session transport. Start
+  with docs (the block model with `docxIndex` anchors is already
+  patch-friendly); sheets can evaluate the Univer ecosystem.
+- **Presence & awareness**: cursors, selections — and the agent shows up as a
+  participant with its own cursor while it works.
+- **Open-source reference sync server** (natural candidate for the `ee/`
+  directory for enterprise variants: SSO, retention, private deploy), keeping
+  the product 100% functional offline and peer-to-peer on a local network.
+- **Shared working sessions with agents**: multiple humans + one Hermes in the
+  same session, with a proposal queue and per-participant permissions.
 
-## Fase 4 — O office do futuro (exploratório)
+## Phase 4 — The office of the future (exploratory)
 
-- **Documentos vivos**: blocos ligados a fontes (uma tabela do sheets embutida
-  no docs, um range que alimenta um gráfico no slides) com recomputação
-  reativa.
-- **Agente proativo com consentimento**: Hermes observa o documento (opt-in) e
-  sugere — "esses números não batem com a planilha anexa" — sempre como
-  proposta, nunca como mutação.
-- **Geração cruzada**: "transforme este relatório em deck" como pipeline entre
-  engines, não como prompt gigante.
-- **Voz e reunião**: ditar edições, transcrever reunião direto num docs com o
-  agente estruturando em tempo real.
+- **Living documents**: blocks linked to sources (a sheets table embedded in
+  docs, a range feeding a chart in slides) with reactive recomputation.
+- **Proactive agent with consent**: Hermes watches the document (opt-in) and
+  suggests — "these numbers don't match the attached spreadsheet" — always as
+  a proposal, never as a mutation.
+- **Cross-generation**: "turn this report into a deck" as a pipeline between
+  engines, not one giant prompt.
+- **Voice and meetings**: dictate edits, transcribe a meeting straight into
+  docs with the agent structuring it in real time.
 
-## Como a comunidade pode ajudar agora
+## How the community can help now
 
-| Perfil                 | Por onde começar                                                      |
-| ---------------------- | --------------------------------------------------------------------- |
-| Primeiro PR            | TODOs mapeados (slicers, pivot, z-order, IME), testes de `agent-core` |
-| TypeScript/React       | Unificação do proposed-change (Fase 1), paridade do app PDF           |
-| Interessado em agentes | MCP server embutido, skills Hermes, plugins runtime                   |
-| Rust                   | Sidecar xlsx (pivot externo, performance)                             |
-| Distributed systems    | RFC da camada CRDT (Fase 3) — abra uma issue de design antes de codar |
-| Docs/i18n              | Guias de setup do gateway Hermes, traduções em `packages/i18n`        |
+| Profile             | Where to start                                                     |
+| ------------------- | ------------------------------------------------------------------ |
+| First PR            | Mapped TODOs (slicers, pivot, z-order, IME), `agent-core` tests    |
+| TypeScript/React    | Proposed-change unification (Phase 1), PDF app parity              |
+| Agent enthusiasts   | Embedded MCP server, Hermes skills, runtime plugins                |
+| Rust                | xlsx sidecar (external pivots, performance)                        |
+| Distributed systems | CRDT layer RFC (Phase 3) — open a design issue before writing code |
+| Docs/i18n           | Hermes gateway setup guides, translations in `packages/i18n`       |
 
-Regras de contribuição em [CONTRIBUTING.md](../CONTRIBUTING.md). Para
-mudanças arquiteturais (Fases 2–3), abra primeiro uma issue `rfc` descrevendo
-o design — merge de código estrutural sem RFC prévia tende a ser devolvido.
+Contribution rules in [CONTRIBUTING.md](../CONTRIBUTING.md). For architectural
+changes (Phases 2–3), open an `rfc` issue describing the design first —
+structural code merged without a prior RFC tends to be sent back.


### PR DESCRIPTION
Adds `docs/ROADMAP.md`: a community roadmap proposal grounded in a code-level audit of the fork.

**Diagnosis highlights (from reading the code):**
- AI trust UX is inconsistent: sheets has propose→review→apply diffs; docs/slides use snapshot+rollback; pdf has neither (and doesn't force the `hermes` provider like the other apps).
- Collaboration is nonexistent (no CRDT/sync/presence); comments/track-changes are single-user OOXML.
- Extensibility is compile-time only (`AgentSkill`); no MCP host or user scripting.
- Hermes integration items still open (gateway health-check, launcher, document skills).
- Test coverage is engine-heavy, agent-core-light.

**Proposed phases:**
1. Consolidate AI foundation — unified proposed-change contract in `agent-core`, PDF parity, close pending Hermes items, agent-core tests.
2. Document as agent surface — embedded MCP servers per app, agent authorship in OOXML revisions, headless CLI, runtime plugin system.
3. Human+agent collaboration — optional CRDT layer, presence (agents as participants), reference sync server (`ee/` hook).
4. Exploratory — live documents, proactive agent with consent, cross-engine generation, voice.

Includes a "how to contribute now" table by profile and an RFC-first rule for structural changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MFy2gNzWUYNvwiUJKRzYGz

---
_Generated by [Claude Code](https://claude.ai/code/session_01MFy2gNzWUYNvwiUJKRzYGz)_