### PR TITLE
fix(updater): never swap while the app is alive; verify the relaunch

### DIFF
--- a/tools/hermesoffice-update.mjs
+++ b/tools/hermesoffice-update.mjs
@@ -144,15 +144,38 @@ function verifyBundle(appPath) {
     throw new Error('bundle verification failed: unreadable build-info.json')
 }
 
-function cmdInstall() {
-  // Wait for the running app to release the bundle (the shell quits first, but
-  // be defensive: poll up to 30s).
-  progress(97, 'waiting for app to quit')
-  const deadline = Date.now() + 30_000
+/** true while any HermesOffice GUI process is alive */
+function appRunning() {
+  return spawnSync('pgrep', ['-x', 'HermesOffice'], { encoding: 'utf8' }).status === 0
+}
+
+function waitAppGone(ms) {
+  const deadline = Date.now() + ms
   while (Date.now() < deadline) {
-    const p = spawnSync('pgrep', ['-x', 'HermesOffice'], { encoding: 'utf8' })
-    if (p.status !== 0) break
+    if (!appRunning()) return true
     spawnSync('sleep', ['1'])
+  }
+  return !appRunning()
+}
+
+function cmdInstall() {
+  // The swap must NEVER happen with the app alive: a surviving process holds
+  // the Electron single-instance lock, the relaunch `open -n` then no-ops
+  // silently, and the old main process keeps running against the new asar —
+  // a mixed-version state that renders the UI broken (raw CSS as text).
+  // Grace period first (the shell quits itself), then TERM, then KILL, and
+  // hard-abort if something still survives.
+  progress(97, 'waiting for app to quit')
+  if (!waitAppGone(30_000)) {
+    console.error('app still running after 30s — sending SIGTERM')
+    spawnSync('pkill', ['-x', 'HermesOffice'])
+    if (!waitAppGone(10_000)) {
+      console.error('app ignored SIGTERM — sending SIGKILL')
+      spawnSync('pkill', ['-9', '-x', 'HermesOffice'])
+      if (!waitAppGone(5_000)) {
+        throw new Error('HermesOffice is still running; refusing to swap a live bundle')
+      }
+    }
   }
   const staged = join(STAGE_DIR, 'HermesOffice.app')
   if (!existsSync(staged)) throw new Error(`no staged app at ${staged} — run build first`)
@@ -187,8 +210,25 @@ function cmdInstall() {
   // relaunched GUI would start in Node mode instead of normal Electron mode.
   const relaunchEnv = { ...process.env }
   delete relaunchEnv.ELECTRON_RUN_AS_NODE
+  // `open -n` can no-op silently (e.g. LaunchServices confusion right after a
+  // bundle swap) — verify the process actually appeared and retry once.
   spawnSync('open', ['-n', APP_PATH], { stdio: 'ignore', env: relaunchEnv })
-  console.log(`RESULT ${JSON.stringify({ installed: APP_PATH, commit: builtCommit(APP_PATH) })}`)
+  let relaunched = false
+  for (let i = 0; i < 10 && !relaunched; i++) {
+    spawnSync('sleep', ['1'])
+    relaunched = appRunning()
+  }
+  if (!relaunched) {
+    console.error('relaunch did not surface a HermesOffice process — retrying open -n')
+    spawnSync('open', ['-n', APP_PATH], { stdio: 'ignore', env: relaunchEnv })
+    for (let i = 0; i < 10 && !relaunched; i++) {
+      spawnSync('sleep', ['1'])
+      relaunched = appRunning()
+    }
+  }
+  console.log(
+    `RESULT ${JSON.stringify({ installed: APP_PATH, commit: builtCommit(APP_PATH), relaunched })}`,
+  )
 }
 
 const [cmd] = process.argv.slice(2)


### PR DESCRIPTION
Completes the #22 hardening with the second failure mode reconstructed from a real broken install.

## The observed failure

The bundle swap happened while an old HermesOffice process was still alive. That process held the Electron **single-instance lock**, so the post-swap `open -n` **no-op'd silently**, and the old main process kept running against the freshly swapped `app.asar` — a mixed-version state (old main + new renderer assets) that renders the UI broken, with raw CSS (`home.css`) displayed as page text. The installer's 30s grace period only *waited*; it never enforced the quit, and the relaunch result was never checked.

## Fix (in `tools/hermesoffice-update.mjs` `cmdInstall`)

1. **Enforced quit before the swap**: after the 30s grace period the installer escalates — `SIGTERM`, wait 10s, `SIGKILL`, wait 5s — and **hard-aborts the swap** if any `HermesOffice` process still survives. The atomic swap from #22 then never runs against a live bundle.
2. **Verified relaunch**: after the swap, the helper polls up to 10s for the process to actually appear, retries `open -n` once if it didn't, and reports `relaunched` in the `RESULT` line so a failed relaunch is visible instead of silent.

Together with #22 (verify + atomic swap + rollback), the two field failure modes — partial bundle and mixed-version live process — are both closed.

## Verification
- `node --check` clean; Prettier clean. macOS-only path; logic reviewed against the reconstructed timeline (swap at 10:30 with PID from 10:28 alive, renderer born post-swap).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MFy2gNzWUYNvwiUJKRzYGz

---
_Generated by [Claude Code](https://claude.ai/code/session_01MFy2gNzWUYNvwiUJKRzYGz)_