### PR TITLE
fix(updater): full-checkout clone + readable version labels (macOS source update)

### DIFF
--- a/apps/shell/package.json
+++ b/apps/shell/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@hermesoffice/shell",
   "productName": "HermesOffice",
-  "version": "0.4.0",
+  "version": "0.5.1",
   "license": "Apache-2.0",
   "private": true,
   "description": "Unified HermesOffice shell: one app hosting the docs and sheets modules behind a home/launcher window",

--- a/apps/shell/src/main/main-updater.ts
+++ b/apps/shell/src/main/main-updater.ts
@@ -188,13 +188,13 @@ function spawnHelper(
 async function ensureSource(): Promise<void> {
   if (existsSync(join(sourceDir(), '.git'))) return
   await new Promise<void>((resolve, reject) => {
-    const child = spawn(
-      'git',
-      ['clone', '--filter=blob:none', '--no-checkout', REPO_URL, sourceDir()],
-      {
-        stdio: ['ignore', 'ignore', 'pipe'],
-      },
-    )
+    // Full working tree — NEVER --no-checkout. The helper script
+    // (tools/hermesoffice-update.mjs) lives inside the checkout and is spawned
+    // right after this clone; with an empty checkout the spawn fails with
+    // ENOENT and the UI reports a bogus "download failed, check your network".
+    const child = spawn('git', ['clone', '--filter=blob:none', REPO_URL, sourceDir()], {
+      stdio: ['ignore', 'ignore', 'pipe'],
+    })
     child.stderr.on('data', (d: Buffer) => log('clone:', d.toString().trim()))
     child.on('error', reject)
     child.on('close', (code) =>
@@ -209,7 +209,7 @@ async function checkForUpdate(getWindow: () => BrowserWindow | null): Promise<vo
     log('no build-info.json in bundle — update check skipped')
     return
   }
-  const builtVer = builtVersion() ?? built.slice(0, 7)
+  const builtVer = builtVersion() ?? `build ${built.slice(0, 7)}`
   const main = await fetchMainCommit()
   if (!main) {
     log('could not reach origin/main — network offline?')
@@ -222,13 +222,15 @@ async function checkForUpdate(getWindow: () => BrowserWindow | null): Promise<vo
   if (main === dismissedCommit) return
   // Semantic version label for the target: the newest ho-v* release tag when
   // main sits on it, otherwise the tag plus the ahead-commit (SemVer build
-  // metadata form, e.g. "0.5.0+abc1234"); bare SHA only as last resort.
+  // metadata form, e.g. "0.5.0+abc1234"). When no tag exists at all, label the
+  // value explicitly as a build — a bare SHA is not a version, and presenting
+  // it as one is what produced the misleading "v0.4.0 → v93a7024" display.
   const tag = await fetchLatestForkTag()
   const newVersion = tag
     ? tag.commit === main
       ? tag.label
       : `${tag.label}+${main.slice(0, 7)}`
-    : main.slice(0, 7)
+    : `build ${main.slice(0, 7)}`
   log('update available:', builtVer, '→', newVersion)
 
   // Attention in background: dock badge + bounce + system notification,

--- a/apps/shell/tests/main-updater.test.ts
+++ b/apps/shell/tests/main-updater.test.ts
@@ -30,24 +30,105 @@ vi.mock('node:child_process', () => ({
   spawn: (...args: unknown[]) => spawn(...args),
 }))
 
+const showUpdateWindow = vi.fn()
+const pushUpdateState = vi.fn()
+const closeUpdateWindow = vi.fn()
+
+vi.mock('../src/main/update-window', () => ({
+  showUpdateWindow: (...args: unknown[]) => showUpdateWindow(...args),
+  pushUpdateState: (...args: unknown[]) => pushUpdateState(...args),
+  closeUpdateWindow: (...args: unknown[]) => closeUpdateWindow(...args),
+}))
+
+const initialState = vi.fn((version: string) => ({
+  phase: 'available',
+  version,
+  currentVersion: '0.0.0',
+  percent: 0,
+  strings: {},
+}))
+
+vi.mock('../src/main/updater', () => ({
+  initialState: (...args: unknown[]) => initialState(...args),
+}))
+
 async function loadMainUpdater() {
   return import('../src/main/main-updater')
 }
+
+const BUILT_SHA = 'a'.repeat(40)
+const MAIN_SHA = 'b'.repeat(40)
+const TAG_SHA = 'c'.repeat(40)
+
+/** fake child_process.ChildProcess with manual emit control. The caller
+ * schedules a process.nextTick that calls emitData()/emit('close') AFTER the
+ * real module attached its listeners (vi.useFakeTimers() also fakes
+ * queueMicrotask, so nextTick is the reliable async primitive here) */
+function fakeChild() {
+  const listeners: Record<string, Array<(...args: unknown[]) => void>> = {}
+  return {
+    stdout: {
+      on: (ev: string, cb: (d: Buffer) => void) => {
+        listeners[`stdout:${ev}`] = [...(listeners[`stdout:${ev}`] ?? []), cb]
+      },
+    },
+    stderr: { on: () => {} },
+    on: (ev: string, cb: (...args: unknown[]) => void) => {
+      listeners[ev] = [...(listeners[ev] ?? []), cb]
+    },
+    emit(ev: string, ...args: unknown[]) {
+      for (const cb of listeners[ev] ?? []) cb(...args)
+    },
+    emitData(data: string) {
+      for (const cb of listeners['stdout:data'] ?? []) cb(Buffer.from(data))
+    },
+  }
+}
+
+/** wire the fake spawn: ls-remote main → MAIN_SHA, ls-remote --tags →
+ * tagScript (test-controlled), everything else → close(0) */
+function mockLsRemote(tagScript: () => string): void {
+  spawn.mockImplementation((cmd: string, args: string[]) => {
+    const child = fakeChild()
+    process.nextTick(() => {
+      if (args.includes('refs/heads/main')) {
+        child.emitData(`${MAIN_SHA}\trefs/heads/main\n`)
+      } else if (args.includes('--tags')) {
+        child.emitData(tagScript())
+      }
+      child.emit('close', 0)
+    })
+    return child
+  })
+}
+
+const realPlatform = process.platform
 
 beforeEach(() => {
   vi.resetModules()
   vi.useFakeTimers()
   appState.isPackaged = true
+  // the main-updater only arms on macOS/Windows; pin darwin so the check flow
+  // runs identically on Linux CI runners
+  Object.defineProperty(process, 'platform', { value: 'darwin', configurable: true })
+  // Electron-only in packaged builds; the fs mock keys off the path suffix,
+  // so an arbitrary value is fine — but it must be a string
+  process.resourcesPath = '/fake/resources'
   appOn.mockClear()
   existsSync.mockReset()
   existsSync.mockReturnValue(false)
   readFileSync.mockReset()
   spawn.mockReset()
+  showUpdateWindow.mockClear()
+  pushUpdateState.mockClear()
+  closeUpdateWindow.mockClear()
+  initialState.mockClear()
   delete process.env.HERMESOFFICE_ENABLE_SOURCE_UPDATE
 })
 
 afterEach(() => {
   vi.useRealTimers()
+  Object.defineProperty(process, 'platform', { value: realPlatform, configurable: true })
   delete process.env.HERMESOFFICE_ENABLE_SOURCE_UPDATE
 })
 
@@ -72,5 +153,104 @@ describe('initMainUpdater safety gate', () => {
     expect(vi.getTimerCount()).toBe(0)
     expect(appOn).not.toHaveBeenCalled()
     expect(spawn).not.toHaveBeenCalled()
+  })
+})
+
+describe('update check version labels', () => {
+  function bootWithUpdate(): void {
+    process.env.HERMESOFFICE_ENABLE_SOURCE_UPDATE = '1'
+    // build-info.json present, app-update.yml absent, no pre-existing source dir
+    existsSync.mockImplementation((path) => String(path).endsWith('build-info.json'))
+    readFileSync.mockReturnValue(JSON.stringify({ commit: BUILT_SHA, version: '0.4.0' }))
+    mockLsRemote(() => tagScript)
+  }
+
+  // set by each test before initMainUpdater runs
+  let tagScript = ''
+
+  it('labels the target as "build <sha>" when no ho-v tag exists (no bare SHA)', async () => {
+    tagScript = ''
+    bootWithUpdate()
+
+    const { initMainUpdater } = await loadMainUpdater()
+    initMainUpdater(() => null)
+    await vi.advanceTimersByTimeAsync(15_000)
+
+    expect(showUpdateWindow).toHaveBeenCalledTimes(1)
+    const state = showUpdateWindow.mock.calls[0][1]
+    expect(state.version).toBe(`build ${MAIN_SHA.slice(0, 7)}`)
+  })
+
+  it('shows the ho-v tag SemVer when main sits on a release tag', async () => {
+    tagScript = `${TAG_SHA}\trefs/tags/ho-v0.5.0\n`
+    bootWithUpdate()
+    // main IS the tag commit → plain SemVer, no build metadata
+    spawn.mockImplementation((cmd: string, args: string[]) => {
+      const child = fakeChild()
+      process.nextTick(() => {
+        if (args.includes('refs/heads/main')) {
+          child.emitData(`${TAG_SHA}\trefs/heads/main\n`)
+        } else if (args.includes('--tags')) {
+          child.emitData(tagScript)
+        }
+        child.emit('close', 0)
+      })
+      return child
+    })
+
+    const { initMainUpdater } = await loadMainUpdater()
+    initMainUpdater(() => null)
+    await vi.advanceTimersByTimeAsync(15_000)
+
+    expect(showUpdateWindow).toHaveBeenCalledTimes(1)
+    const state = showUpdateWindow.mock.calls[0][1]
+    expect(state.version).toBe('0.5.0')
+  })
+
+  it('shows tag + ahead-commit form when main is past the newest tag', async () => {
+    tagScript = `${TAG_SHA}\trefs/tags/ho-v0.4.0\n`
+    bootWithUpdate()
+
+    const { initMainUpdater } = await loadMainUpdater()
+    initMainUpdater(() => null)
+    await vi.advanceTimersByTimeAsync(15_000)
+
+    expect(showUpdateWindow).toHaveBeenCalledTimes(1)
+    const state = showUpdateWindow.mock.calls[0][1]
+    expect(state.version).toBe(`0.4.0+${MAIN_SHA.slice(0, 7)}`)
+  })
+})
+
+describe('first download (ensureSource)', () => {
+  it('clones a full working tree — no --no-checkout — before spawning the helper', async () => {
+    process.env.HERMESOFFICE_ENABLE_SOURCE_UPDATE = '1'
+    existsSync.mockImplementation((path) => String(path).endsWith('build-info.json'))
+    readFileSync.mockReturnValue(JSON.stringify({ commit: BUILT_SHA, version: '0.4.0' }))
+
+    const spawnArgs: string[][] = []
+    spawn.mockImplementation((cmd: string, args: string[]) => {
+      spawnArgs.push([cmd, ...args])
+      const child = fakeChild()
+      process.nextTick(() => {
+        if (args.includes('refs/heads/main')) child.emitData(`${MAIN_SHA}\trefs/heads/main\n`)
+        else if (args.includes('--tags')) child.emitData(`${TAG_SHA}\trefs/tags/ho-v0.5.0\n`)
+        child.emit('close', 0)
+      })
+      return child
+    })
+
+    const { initMainUpdater } = await loadMainUpdater()
+    initMainUpdater(() => null)
+    await vi.advanceTimersByTimeAsync(15_000)
+
+    // trigger the download flow the UI wires to the "update" button
+    const actions = showUpdateWindow.mock.calls[0][2] as { onDownload: () => void }
+    actions.onDownload()
+    await vi.advanceTimersByTimeAsync(100)
+
+    const cloneCall = spawnArgs.find((c) => c[0] === 'git' && c[1] === 'clone')
+    expect(cloneCall).toBeDefined()
+    expect(cloneCall).not.toContain('--no-checkout')
+    expect(cloneCall).toContain('--filter=blob:none')
   })
 })

--- a/tools/hermesoffice-update.mjs
+++ b/tools/hermesoffice-update.mjs
@@ -162,7 +162,11 @@ function cmdPrepare() {
   if (!existsSync(join(SOURCE_DIR, '.git'))) {
     mkdirSync(dirname(SOURCE_DIR), { recursive: true })
     progress(10, 'cloning')
-    run('git', ['clone', '--filter=blob:none', '--no-checkout', REPO, SOURCE_DIR], {
+    // Full working tree — NEVER --no-checkout. The subsequent fetch/reset/npm
+    // steps need a real checkout, and the app spawns this very script from
+    // inside it; an empty checkout breaks both (ENOENT → "download failed,
+    // check your network" in the UI).
+    run('git', ['clone', '--filter=blob:none', REPO, SOURCE_DIR], {
       timeout: 120_000,
     })
   }

--- a/tools/hermesoffice-update.test.mjs
+++ b/tools/hermesoffice-update.test.mjs
@@ -139,6 +139,54 @@ test('prepare resolves npm outside the minimal PATH (fake sh reports it)', () =>
   }
 })
 
+test('prepare clones with a full working tree (no --no-checkout)', () => {
+  // Regression: the clone used --no-checkout, so the helper script itself
+  // (spawned from inside the checkout) did not exist and every first download
+  // died with a bogus "check your network" error. prepare must clone a real
+  // working tree.
+  const temp = mkdtempSync(join(tmpdir(), 'hermesoffice-update-test-'))
+  try {
+    const bin = join(temp, 'bin')
+    const src = join(temp, 'src')
+    const gitLog = join(temp, 'git-args.txt')
+    mkdirSync(bin, { recursive: true })
+    // fake git: log every invocation (clone must appear without --no-checkout)
+    // and create the destination dir so the later `npm ci` (cwd=SOURCE_DIR) runs
+    executable(
+      join(bin, 'git'),
+      `printf '%s\\n' "$*" >> "${gitLog}"; [ "$1" = "clone" ] && mkdir -p "$4"; exit 0`,
+    )
+    // npm resolution: fake sh reports the fake npm, which must succeed
+    executable(join(bin, 'sh'), `printf '%s\\n' "${bin}/npm"`)
+    executable(join(bin, 'npm'), 'exit 0')
+
+    const result = spawnSync(process.execPath, [HELPER, 'prepare'], {
+      encoding: 'utf8',
+      env: {
+        ...process.env,
+        PATH: `${bin}:/usr/bin:/bin`,
+        HERMESOFFICE_SOURCE_DIR: src,
+      },
+    })
+    assert.equal(result.status, 0, result.stderr || result.stdout)
+
+    const cloneLine = readFileSync(gitLog, 'utf8')
+      .split('\n')
+      .find((line) => line.includes('clone'))
+    assert.ok(cloneLine, 'prepare must run a git clone: ' + readFileSync(gitLog, 'utf8'))
+    assert.ok(
+      !cloneLine.includes('--no-checkout'),
+      `clone must not use --no-checkout: ${cloneLine}`,
+    )
+    assert.ok(
+      cloneLine.includes('--filter=blob:none'),
+      `clone keeps blob:none filter: ${cloneLine}`,
+    )
+  } finally {
+    rmSync(temp, { recursive: true, force: true })
+  }
+})
+
 test('install does not wait out the poll window on its own process (pgrep self-match)', () => {
   // Regression: the helper runs through the packaged HermesOffice binary
   // (ELECTRON_RUN_AS_NODE), so `pgrep -x HermesOffice` matches the helper


### PR DESCRIPTION
## Problema

O usuário no Mac mini não conseguia atualizar: (1) a UI mostrava `v0.4.0 → v93a7024` (hash cru como versão) e (2) o primeiro download sempre falhava com *"falha no download, verifique sua rede"*.

## Causa raiz

- `git clone --filter=blob:none --no-checkout` (em `ensureSource` do main process **e** em `cmdPrepare` do helper) produzia um checkout **vazio**. O app spawna `tools/hermesoffice-update.mjs` de dentro desse checkout — o arquivo não existia, o spawn falhava com ENOENT e a UI reportava o erro genérico de rede.
- Sem tag `ho-v*`, o label da versão alvo caía no SHA puro (`93a7024`), que não é uma versão.

## Fix

- **Clone com working tree completa** nos dois pontos (nunca `--no-checkout`), para o helper existir no checkout antes do spawn.
- **Labels de versão legíveis**: com tag `ho-v*` → SemVer (puro se main == tag; `+<sha7>` se à frente); sem tag → `build <sha7>` explícito, nunca SHA como versão.
- Bump `@hermesoffice/shell` → `0.5.1` (main já tem `ho-v0.5.0`; 0.4.1 regrediria). Tag `ho-v0.5.1` criada no commit.

## Testes

- ✅ `npm run test -w @hermesoffice/shell` — 127 testes (novos: labels de versão em 3 cenários + clone sem `--no-checkout`)
- ✅ `node --test tools/hermesoffice-update.test.mjs` — 5 testes (novo: prepare clona working tree completa, sem `--no-checkout`)
- ✅ typecheck, eslint, prettier, `git diff --check`

> Obs.: como o defeito está no updater já instalado (0.4.0), essa instalação não consegue baixar o código que corrige o próprio updater — o primeiro pacote 0.5.1 precisa ser instalado manualmente; a partir daí o fluxo corrigido funciona.