### PR TITLE
spike(39): minimal embedded MCP server for a real docx (VALIDATED)

### DIFF
--- a/spikes/001-mcp-docx/.gitignore
+++ b/spikes/001-mcp-docx/.gitignore
@@ -1,0 +1,2 @@
+# scratch .docx copies (copied from templates/docs/ for each test run)
+*.docx

--- a/spikes/001-mcp-docx/README.md
+++ b/spikes/001-mcp-docx/README.md
@@ -1,0 +1,160 @@
+# Spike 001 — Minimal embedded MCP server for a real `.docx`
+
+**Issue:** #39 · **Question:** are the docs AI-panel tools (`read_blocks` /
+`replace_blocks`) reusable as-is behind an MCP transport, or do they require a
+session-scoped redesign (ProseMirror editor context)?
+
+**Bet (from the issue):** the tools already exist and MCP is just transport.
+**Risk:** the tools are wired to the in-app chat context (block list embedded
+in the first message, per-document session via `X-Hermes-Session-Id`) — a
+session-scoped model, not request-scoped. If exposing them requires redesigning
+the tool context, the Phase 2 estimate doubles.
+
+## Approach
+
+A **transport-only, request-scoped** server: every tool call parses the `.docx`
+fresh with the `docx-engine` (`parseDocx` → `Block[]`), operates on the block
+tree, and writes back with `saveDocx` (byte-preserving). No editor, no
+renderer, no session, no ProseMirror.
+
+- `server.mjs` — MCP stdio server (JSON-RPC 2.0 hand-rolled, zero external
+  dependency beyond the workspace `@hermesoffice/docx-engine`)
+- `client.mjs` — MCP client harness (drives initialize → tools/list →
+  read_blocks → replace_blocks → read_blocks)
+- `debug-wrapper.mjs` — protocol logger used while diagnosing the Hermes CLI
+  handshake
+
+Tools exposed:
+- `read_blocks(startBlockIndex, endBlockIndex)` — block tree of the docx
+  (`index | type | content-preview`), hidden blocks filtered
+- `replace_blocks(startBlockIndex, endBlockIndex, html)` — replaces a range
+  with a generated paragraph, runs through a **ProposedChange record
+  (RFC 0008)** with a stub auto-approve policy, writes an audit log, and saves
+  the docx byte-preserving
+
+## Running it
+
+```bash
+# standalone harness (spawns the server over stdio, drives the full flow)
+cp ../../templates/docs/meeting-notes.docx ./test.docx
+node ../../node_modules/.bin/tsx client.mjs "$(pwd)/test.docx"
+
+# as a real Hermes MCP client (config is already saved in ~/.hermes/config.yaml)
+hermes mcp test spike39
+
+# a fresh copy per run (the server mutates the file in place)
+cp ../../templates/docs/meeting-notes.docx ./test3.docx
+hermes mcp test spike39
+```
+
+Audit records land in `~/.hermesoffice-spike39-audit/`.
+
+## Results
+
+```
+[initialize] server: hermesoffice-docx-spike39 v0.0.1
+[tools/list] read_blocks, replace_blocks
+[read_blocks 0..4]
+visible blocks: 16
+0	h1	Meeting Notes — [Topic]
+1	paragraph	Template note for AI agents: ...
+2	paragraph	Date: [YYYY-MM-DD] ...
+3	paragraph	Attendees: [Names] ...
+4	h2	Agenda
+
+[replace_blocks 0..0]
+replaced blocks 0..0; docx saved (3201 bytes)
+audit: ~/.hermesoffice-spike39-audit/spike39-….json
+sha256 before: 1808815…
+sha256 after:  3223c65…
+
+[read_blocks 0..2 after replace]
+0	h1	Spike 39 MCP edit: this paragraph was replaced by an external agent via MCP.
+```
+
+Byte-preservation, per zip part (untouched parts must be bit-identical):
+
+```
+✓ word/styles.xml IDÊNTICA      ✓ word/theme/theme1.xml IDÊNTICA
+✓ word/fontTable.xml IDÊNTICA   ✓ [Content_Types].xml IDÊNTICA
+✓ word/settings.xml IDÊNTICA    ✓ _rels/.rels IDÊNTICA
+✓ word/document.xml mudou (esperado — the edited part)
+```
+
+Edge cases: out-of-range block index → clean error (`block index out of range
+(doc has 16 visible blocks)`), no mutation, no audit record.
+
+Real MCP client (Hermes CLI):
+
+```
+hermes mcp test spike39
+  ✓ Connected (245ms)
+  ✓ Tools discovered: 2
+    read_blocks      Read the block tree of the .docx …
+    replace_blocks   Replace a block range with new text. …
+```
+
+## Verdict: VALIDATED
+
+### What worked
+- **Transport-only is real.** The engine (`parseDocx` → `Block[]` →
+  `saveDocx`) is pure Node and request-scoped by nature. The spike exposed the
+  two tools with **zero changes to the engine and zero ProseMirror** — the
+  "context redesign" the issue feared was **not** needed at the engine level.
+- Byte-preserving round-trip confirmed per zip part: all untouched parts
+  bit-identical, only `document.xml` changed.
+- The mutation correctly flowed through the RFC 0008 `ProposedChangeRecord`
+  shape (status `applied`, actor `agent`, scope, payload) into an audit log —
+  the store schema in `@hermesoffice/project-store` already matches.
+- `rawPPr` preservation: replacing a `h1` block with a generated paragraph
+  kept the heading style (block re-parsed as `h1`) — format fidelity holds.
+- Real Hermes MCP client connects and discovers both tools.
+
+### What didn't / constraints
+- **The tools are not 1:1 reusable as-is.** `read_blocks`/`replace_blocks` in
+  the AI panel operate on the ProseMirror `Editor` (the renderer), not on the
+  engine block tree. The spike re-implemented them against `docx-engine`
+  directly (~150 lines). The **transport** is reusable; the **tool bodies**
+  need a headless twin (engine-backed) — a moderate, bounded cost, NOT a
+  redesign of the session model.
+- `replace_blocks` in the spike replaces a range with a **single generated
+  paragraph of plain text**. The panel tool accepts restricted HTML and
+  multiple blocks; multi-block/rich-HTML replacement needs the renderer's
+  `parseHtmlFragment` logic ported (or shared) — follow-up work.
+- Stub approval policy only (auto-approve, audited). The real approval model
+  RFC (issue #38) is still design.
+- The local `hermes` CLI binary has an argparse regression (`-z`/positional
+  prompt rejected) unrelated to the spike; E2E was proven via `hermes mcp
+  test` and the harness client instead.
+
+### Surprises
+- `hermes mcp add` flag ordering: `--env`/`--connect-timeout` must come
+  **before** `--args` (which consumes the rest of argv). Mistakenly placed
+  after, they land in the server's `args` and the config is malformed.
+- The workspace packages export TS source directly (`"exports": {".":
+  "./src/index.ts"}`), so any external consumer must run through `tsx` (the
+  repo's own tooling does this everywhere).
+
+### Recommendation for the real build (Phase 2 keystone)
+1. **Build the headless tool twin as a real package** (e.g.
+   `packages/docx-mcp` or a `tools/` module in the docs main process): engine-
+   backed `read_blocks`/`replace_blocks` with the RFC 0008 proposal gate and
+   `project-store` persistence (not a flat audit dir).
+2. **Reuse the real MCP SDK** (`@modelcontextprotocol/sdk`) instead of the
+   hand-rolled JSON-RPC loop — the spike proves the protocol fits; the SDK
+   removes the edge cases (ping, resources, logging, shutdown).
+3. **Share `parseHtmlFragment`** (renderer → engine or a shared package) so
+   MCP `replace_blocks` accepts the same restricted HTML as the panel tool.
+4. Wire the approval model (issue #38) to the proposal status lifecycle —
+   the `draft → proposed → accepted → applied` states already exist in the
+   store schema.
+5. **Cost estimate for Phase 2 keystone:** the feared "context redesign" is
+   NOT needed. The delta is a headless tool twin + MCP SDK wrapper + approval
+   policy — roughly **half the originally feared estimate**.
+
+## Files
+
+- `server.mjs` — MCP stdio server (engine-backed, RFC 0008 gate, audit log)
+- `client.mjs` — MCP client harness (full flow demo)
+- `debug-wrapper.mjs` — protocol logger (diagnostics)
+- `test*.docx` — scratch copies of `templates/docs/meeting-notes.docx`

--- a/spikes/001-mcp-docx/README.md
+++ b/spikes/001-mcp-docx/README.md
@@ -25,6 +25,7 @@ renderer, no session, no ProseMirror.
   handshake
 
 Tools exposed:
+
 - `read_blocks(startBlockIndex, endBlockIndex)` — block tree of the docx
   (`index | type | content-preview`), hidden blocks filtered
 - `replace_blocks(startBlockIndex, endBlockIndex, html)` — replaces a range
@@ -97,6 +98,7 @@ hermes mcp test spike39
 ## Verdict: VALIDATED
 
 ### What worked
+
 - **Transport-only is real.** The engine (`parseDocx` → `Block[]` →
   `saveDocx`) is pure Node and request-scoped by nature. The spike exposed the
   two tools with **zero changes to the engine and zero ProseMirror** — the
@@ -111,6 +113,7 @@ hermes mcp test spike39
 - Real Hermes MCP client connects and discovers both tools.
 
 ### What didn't / constraints
+
 - **The tools are not 1:1 reusable as-is.** `read_blocks`/`replace_blocks` in
   the AI panel operate on the ProseMirror `Editor` (the renderer), not on the
   engine block tree. The spike re-implemented them against `docx-engine`
@@ -125,17 +128,19 @@ hermes mcp test spike39
   RFC (issue #38) is still design.
 - The local `hermes` CLI binary has an argparse regression (`-z`/positional
   prompt rejected) unrelated to the spike; E2E was proven via `hermes mcp
-  test` and the harness client instead.
+test` and the harness client instead.
 
 ### Surprises
+
 - `hermes mcp add` flag ordering: `--env`/`--connect-timeout` must come
   **before** `--args` (which consumes the rest of argv). Mistakenly placed
   after, they land in the server's `args` and the config is malformed.
 - The workspace packages export TS source directly (`"exports": {".":
-  "./src/index.ts"}`), so any external consumer must run through `tsx` (the
+"./src/index.ts"}`), so any external consumer must run through `tsx` (the
   repo's own tooling does this everywhere).
 
 ### Recommendation for the real build (Phase 2 keystone)
+
 1. **Build the headless tool twin as a real package** (e.g.
    `packages/docx-mcp` or a `tools/` module in the docs main process): engine-
    backed `read_blocks`/`replace_blocks` with the RFC 0008 proposal gate and

--- a/spikes/001-mcp-docx/client.mjs
+++ b/spikes/001-mcp-docx/client.mjs
@@ -63,7 +63,9 @@ function textOf(result) {
 }
 
 async function main() {
-  const before = createHash('sha256').update(await readFile(docxPath)).digest('hex')
+  const before = createHash('sha256')
+    .update(await readFile(docxPath))
+    .digest('hex')
   console.log(`\n=== target: ${docxPath}`)
   console.log(`sha256 before: ${before}\n`)
 
@@ -72,7 +74,9 @@ async function main() {
     capabilities: {},
     clientInfo: { name: 'spike39-client', version: '0.0.1' },
   })
-  console.log(`[initialize] server: ${init.result?.serverInfo?.name} v${init.result?.serverInfo?.version}`)
+  console.log(
+    `[initialize] server: ${init.result?.serverInfo?.name} v${init.result?.serverInfo?.version}`,
+  )
 
   const tools = await call('tools/list')
   console.log(`[tools/list] ${tools.result?.tools?.map((t) => t.name).join(', ')}`)
@@ -86,7 +90,11 @@ async function main() {
   if (!skipReplace) {
     const rep = await call('tools/call', {
       name: 'replace_blocks',
-      arguments: { startBlockIndex: 0, endBlockIndex: 0, html: 'Spike 39 MCP edit: this paragraph was replaced by an external agent via MCP.' },
+      arguments: {
+        startBlockIndex: 0,
+        endBlockIndex: 0,
+        html: 'Spike 39 MCP edit: this paragraph was replaced by an external agent via MCP.',
+      },
     })
     console.log(`\n[replace_blocks 0..0]\n${textOf(rep.result)}`)
 
@@ -96,7 +104,9 @@ async function main() {
     })
     console.log(`\n[read_blocks 0..2 after replace]\n${textOf(read2.result)}`)
 
-    const after = createHash('sha256').update(await readFile(docxPath)).digest('hex')
+    const after = createHash('sha256')
+      .update(await readFile(docxPath))
+      .digest('hex')
     console.log(`\nsha256 after:  ${after}`)
     console.log(`changed: ${before !== after}`)
   }

--- a/spikes/001-mcp-docx/client.mjs
+++ b/spikes/001-mcp-docx/client.mjs
@@ -10,7 +10,7 @@
  */
 import { spawn } from 'node:child_process'
 import { createHash } from 'node:crypto'
-import { readFile, writeFile, copyFile } from 'node:fs/promises'
+import { readFile } from 'node:fs/promises'
 import { fileURLToPath } from 'node:url'
 import { dirname, join } from 'node:path'
 

--- a/spikes/001-mcp-docx/client.mjs
+++ b/spikes/001-mcp-docx/client.mjs
@@ -1,0 +1,111 @@
+#!/usr/bin/env node
+/**
+ * Spike #39 — MCP client harness.
+ * Spawns server.mjs over stdio and drives the MCP handshake like an external
+ * agent (Hermes CLI / Claude Code) would: initialize → tools/list →
+ * read_blocks → replace_blocks → read_blocks again (verify the edit landed).
+ *
+ * Usage:
+ *   node client.mjs /path/to/file.docx [--skip-replace]
+ */
+import { spawn } from 'node:child_process'
+import { createHash } from 'node:crypto'
+import { readFile, writeFile, copyFile } from 'node:fs/promises'
+import { fileURLToPath } from 'node:url'
+import { dirname, join } from 'node:path'
+
+const here = dirname(fileURLToPath(import.meta.url))
+const docxPath = process.argv[2]
+const skipReplace = process.argv.includes('--skip-replace')
+
+if (!docxPath) {
+  console.error('usage: node client.mjs /path/to/file.docx [--skip-replace]')
+  process.exit(1)
+}
+
+// the workspace packages export TS source ("./src/index.ts"), so the server
+// must run through tsx like the rest of the repo tooling
+const tsxBin = join(here, '..', '..', 'node_modules', '.bin', 'tsx')
+const server = spawn(tsxBin, [join(here, 'server.mjs')], {
+  env: { ...process.env, DOCX_PATH: docxPath },
+  stdio: ['pipe', 'pipe', 'inherit'],
+})
+
+let nextId = 0
+const pending = new Map()
+let buf = ''
+
+server.stdout.setEncoding('utf8')
+server.stdout.on('data', (chunk) => {
+  buf += chunk
+  let idx
+  while ((idx = buf.indexOf('\n')) !== -1) {
+    const line = buf.slice(0, idx).trim()
+    buf = buf.slice(idx + 1)
+    if (!line) continue
+    const msg = JSON.parse(line)
+    if (msg.id && pending.has(msg.id)) {
+      const { resolve } = pending.get(msg.id)
+      pending.delete(msg.id)
+      resolve(msg)
+    }
+  }
+})
+
+function call(method, params = {}) {
+  const id = ++nextId
+  server.stdin.write(JSON.stringify({ jsonrpc: '2.0', id, method, params }) + '\n')
+  return new Promise((resolve) => pending.set(id, { resolve }))
+}
+
+function textOf(result) {
+  return (result.content || []).map((c) => c.text).join('\n')
+}
+
+async function main() {
+  const before = createHash('sha256').update(await readFile(docxPath)).digest('hex')
+  console.log(`\n=== target: ${docxPath}`)
+  console.log(`sha256 before: ${before}\n`)
+
+  const init = await call('initialize', {
+    protocolVersion: '2024-11-05',
+    capabilities: {},
+    clientInfo: { name: 'spike39-client', version: '0.0.1' },
+  })
+  console.log(`[initialize] server: ${init.result?.serverInfo?.name} v${init.result?.serverInfo?.version}`)
+
+  const tools = await call('tools/list')
+  console.log(`[tools/list] ${tools.result?.tools?.map((t) => t.name).join(', ')}`)
+
+  const read1 = await call('tools/call', {
+    name: 'read_blocks',
+    arguments: { startBlockIndex: 0, endBlockIndex: 4 },
+  })
+  console.log(`\n[read_blocks 0..4]\n${textOf(read1.result)}`)
+
+  if (!skipReplace) {
+    const rep = await call('tools/call', {
+      name: 'replace_blocks',
+      arguments: { startBlockIndex: 0, endBlockIndex: 0, html: 'Spike 39 MCP edit: this paragraph was replaced by an external agent via MCP.' },
+    })
+    console.log(`\n[replace_blocks 0..0]\n${textOf(rep.result)}`)
+
+    const read2 = await call('tools/call', {
+      name: 'read_blocks',
+      arguments: { startBlockIndex: 0, endBlockIndex: 2 },
+    })
+    console.log(`\n[read_blocks 0..2 after replace]\n${textOf(read2.result)}`)
+
+    const after = createHash('sha256').update(await readFile(docxPath)).digest('hex')
+    console.log(`\nsha256 after:  ${after}`)
+    console.log(`changed: ${before !== after}`)
+  }
+
+  server.kill()
+}
+
+main().catch((err) => {
+  console.error(err)
+  server.kill()
+  process.exit(1)
+})

--- a/spikes/001-mcp-docx/debug-wrapper.mjs
+++ b/spikes/001-mcp-docx/debug-wrapper.mjs
@@ -1,0 +1,31 @@
+#!/usr/bin/env node
+/**
+ * Debug wrapper: logs every MCP message the client sends, then proxies to
+ * server.mjs. Lets us see exactly which methods the Hermes client calls
+ * during the add/test handshake.
+ */
+import { spawn } from 'node:child_process'
+import { fileURLToPath } from 'node:url'
+import { dirname, join } from 'node:path'
+
+const here = dirname(fileURLToPath(import.meta.url))
+const tsxBin = join(here, '..', '..', 'node_modules', '.bin', 'tsx')
+const child = spawn(tsxBin, [join(here, 'server.mjs')], {
+  env: process.env,
+  stdio: ['pipe', 'pipe', 'inherit'],
+})
+
+process.stdin.setEncoding('utf8')
+let buf = ''
+process.stdin.on('data', (chunk) => {
+  buf += chunk
+  let idx
+  while ((idx = buf.indexOf('\n')) !== -1) {
+    const line = buf.slice(0, idx)
+    buf = buf.slice(idx + 1)
+    if (line.trim()) console.error('[CLIENT →]', line.slice(0, 300))
+    child.stdin.write(line + '\n')
+  }
+})
+child.stdout.on('data', (d) => process.stdout.write(d))
+child.on('exit', () => process.exit(0))

--- a/spikes/001-mcp-docx/server.mjs
+++ b/spikes/001-mcp-docx/server.mjs
@@ -1,0 +1,280 @@
+#!/usr/bin/env node
+/**
+ * Spike #39 — minimal embedded MCP server for a real .docx
+ * =========================================================
+ * Question: are the docs AI-panel tools (read_blocks / replace_blocks)
+ * reusable as-is behind an MCP transport, or do they require a
+ * session-scoped redesign (ProseMirror editor context)?
+ *
+ * This server is deliberately transport-only: MCP stdio (JSON-RPC 2.0 over
+ * stdin/stdout, hand-rolled — no @modelcontextprotocol/sdk dependency) and a
+ * REQUEST-SCOPED backend: every tool call parses the .docx fresh with the
+ * docx-engine (parseDocx → Block[]), operates on the block tree, and writes
+ * back with saveDocx (byte-preserving). No editor, no renderer, no session.
+ *
+ * Tools exposed:
+ *   read_blocks    — read the block tree of the docx (index|type|content)
+ *   replace_blocks — replace a block range; runs through a ProposedChange
+ *                    record (RFC 0008) with a stub auto-approve policy and an
+ *                    audit log; the docx round-trip must stay byte-preserving
+ *
+ * Usage:
+ *   DOCX_PATH=/path/to/file.docx node server.mjs
+ * (talk to it over stdio: initialize → tools/list → tools/call)
+ */
+import { readFile, writeFile } from 'node:fs/promises'
+import { createHash } from 'node:crypto'
+import { mkdirSync } from 'node:fs'
+import { dirname, join } from 'node:path'
+import { homedir } from 'node:os'
+import {
+  parseDocx,
+  saveDocx,
+} from '@hermesoffice/docx-engine'
+
+const DOCX_PATH = process.env.DOCX_PATH
+const AUDIT_DIR =
+  process.env.AUDIT_DIR || join(homedir(), '.hermesoffice-spike39-audit')
+
+if (!DOCX_PATH) {
+  console.error('DOCX_PATH env var required')
+  process.exit(1)
+}
+
+// ── ProposedChange audit (RFC 0008, stub policy) ────────────────────────────
+// The real implementation persists via @hermesoffice/project-store
+// (projects/<id>/proposals/<id>.json). The spike writes the same shape to a
+// flat audit dir so the record is inspectable without the full store.
+
+function auditRecord(op) {
+  const id = `spike39-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`
+  const now = new Date().toISOString()
+  return {
+    id,
+    projectId: 'spike39',
+    filePath: DOCX_PATH,
+    app: 'docs',
+    status: 'applied', // stub policy: auto-approve low-risk, audit logged
+    title: op.title,
+    summary: op.summary,
+    actor: { id: 'mcp-external-agent', name: 'external MCP client', kind: 'agent' },
+    createdAt: now,
+    updatedAt: now,
+    operations: [
+      {
+        id: `${id}-op1`,
+        type: op.type,
+        summary: op.summary,
+        scope: { kind: 'range', ref: `${op.startBlockIndex}..${op.endBlockIndex}`, label: `blocks ${op.startBlockIndex}-${op.endBlockIndex}` },
+        payload: op.payload,
+      },
+    ],
+    risks: [{ level: 'low', message: 'spike stub policy: auto-approved' }],
+  }
+}
+
+async function writeAudit(record) {
+  mkdirSync(AUDIT_DIR, { recursive: true })
+  const p = join(AUDIT_DIR, `${record.id}.json`)
+  await writeFile(p, JSON.stringify(record, null, 2))
+  return p
+}
+
+// ── docx-engine backend (request-scoped) ────────────────────────────────────
+
+async function loadParsed() {
+  const bytes = await readFile(DOCX_PATH)
+  const parsed = await parseDocx(new Uint8Array(bytes))
+  return { bytes, parsed }
+}
+
+function blockText(b) {
+  if (b.type === 'paragraph' || b.type === 'heading' || b.type === 'listItem') {
+    return (b.runs || []).map((r) => r.text).join('')
+  }
+  return b.previewText || b.label || `[${b.type}]`
+}
+
+function blockLine(b, i) {
+  const prefix =
+    b.type === 'heading' ? `h${b.level || 1}` : b.type
+  const content = blockText(b).slice(0, 200).replace(/\n/g, '⏎')
+  return `${i}\t${prefix}\t${content}`
+}
+
+function readBlocks(startBlockIndex, endBlockIndex) {
+  return {
+    output: (async () => {
+      const { parsed } = await loadParsed()
+      const blocks = parsed.blocks.filter((b) => !b.hidden)
+      const s = Number(startBlockIndex) || 0
+      const e = Number(endBlockIndex) ?? blocks.length - 1
+      if (s < 0 || e < s || e >= blocks.length) {
+        return { isError: true, output: `block index out of range (doc has ${blocks.length} visible blocks)` }
+      }
+      const lines = blocks.slice(s, e + 1).map(blockLine)
+      return { isError: false, output: `visible blocks: ${blocks.length}\n${lines.join('\n')}` }
+    })(),
+  }
+}
+
+/** Build SaveBlock[]: keep every original block, replace the target range
+ * with a single generated paragraph carrying the new text. This mirrors what
+ * the renderer's replaceBlockRange produces, minus the ProseMirror layer. */
+function buildSaveBlocks(parsed, startBlockIndex, endBlockIndex, newText) {
+  const visible = parsed.blocks.filter((b) => !b.hidden)
+  const blocks = parsed.blocks
+  // map visible index → real block
+  const target = visible.slice(startBlockIndex, endBlockIndex + 1)
+  const targetDocxIndexes = new Set(target.map((b) => b.docxIndex))
+  const saveBlocks = []
+  for (const b of blocks) {
+    if (b.docxIndex !== null && targetDocxIndexes.has(b.docxIndex)) {
+      if (b === target[0]) {
+        // replace the range with one generated paragraph (keep raw pPr if any)
+        const gen = {
+          kind: 'generated',
+          block: {
+            type: 'paragraph',
+            runs: [{ text: newText }],
+            ...(target[0].rawPPr ? { rawPPr: target[0].rawPPr } : {}),
+          },
+        }
+        saveBlocks.push(gen)
+      }
+      // remaining blocks in the range are dropped
+      continue
+    }
+    saveBlocks.push({ kind: 'original', docxIndex: b.docxIndex })
+  }
+  // hidden trailing elements (sectPr etc.) are appended by the engine
+  return saveBlocks
+}
+
+async function replaceBlocks(startBlockIndex, endBlockIndex, html) {
+  const { bytes, parsed } = await loadParsed()
+  const before = createHash('sha256').update(bytes).digest('hex')
+
+  const visible = parsed.blocks.filter((b) => !b.hidden)
+  const s = Number(startBlockIndex)
+  const e = Number(endBlockIndex)
+  if (!Number.isInteger(s) || !Number.isInteger(e) || s < 0 || e < s || e >= visible.length) {
+    return { isError: true, output: `block index out of range (doc has ${visible.length} visible blocks)` }
+  }
+
+  // RFC 0008 gate: create the proposal record BEFORE mutating bytes
+  const record = auditRecord({
+    title: `Replace blocks ${s}..${e}`,
+    summary: `Replace ${e - s + 1} block(s) with new text`,
+    type: 'replace_blocks',
+    startBlockIndex: s,
+    endBlockIndex: e,
+    payload: { html },
+  })
+  const auditPath = await writeAudit(record)
+
+  const saveBlocks = buildSaveBlocks(parsed, s, e, String(html || ''))
+  const out = await saveDocx(parsed, saveBlocks)
+  await writeFile(DOCX_PATH, out)
+
+  const after = createHash('sha256').update(out).digest('hex')
+  return {
+    isError: false,
+    output: `replaced blocks ${s}..${e}; docx saved (${out.length} bytes)\naudit: ${auditPath}\nsha256 before: ${before}\nsha256 after:  ${after}\nbyte-preserving: untouched parts only — verify with a re-parse`,
+  }
+}
+
+// ── MCP stdio transport (JSON-RPC 2.0, hand-rolled) ─────────────────────────
+
+const TOOLS = [
+  {
+    name: 'read_blocks',
+    description: 'Read the block tree of the .docx (index|type|content preview). Block indexes change after modifications; call again for fresh indexes.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        startBlockIndex: { type: 'integer', description: 'start block index (0-based, inclusive)' },
+        endBlockIndex: { type: 'integer', description: 'end block index (inclusive)' },
+      },
+      required: ['startBlockIndex', 'endBlockIndex'],
+    },
+  },
+  {
+    name: 'replace_blocks',
+    description: 'Replace a block range with new text. Runs through the Proposed Change pipeline (RFC 0008) with a stub auto-approve policy; the change is audited and the docx round-trip is byte-preserving.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        startBlockIndex: { type: 'integer', description: 'start block index (0-based, inclusive)' },
+        endBlockIndex: { type: 'integer', description: 'end block index (inclusive)' },
+        html: { type: 'string', description: 'replacement text (spike: plain text)' },
+      },
+      required: ['startBlockIndex', 'endBlockIndex', 'html'],
+    },
+  },
+]
+
+async function handleCall(name, args) {
+  switch (name) {
+    case 'read_blocks': {
+      const r = await readBlocks(args.startBlockIndex, args.endBlockIndex).output
+      return { content: [{ type: 'text', text: r.output }], isError: !!r.isError }
+    }
+    case 'replace_blocks': {
+      const r = await replaceBlocks(args.startBlockIndex, args.endBlockIndex, args.html)
+      return { content: [{ type: 'text', text: r.output }], isError: !!r.isError }
+    }
+    default:
+      return { content: [{ type: 'text', text: `unknown tool: ${name}` }], isError: true }
+  }
+}
+
+let buf = ''
+process.stdin.setEncoding('utf8')
+process.stdin.on('data', async (chunk) => {
+  buf += chunk
+  let idx
+  while ((idx = buf.indexOf('\n')) !== -1) {
+    const line = buf.slice(0, idx).trim()
+    buf = buf.slice(idx + 1)
+    if (!line) continue
+    let msg
+    try {
+      msg = JSON.parse(line)
+    } catch {
+      continue
+    }
+    const respond = (result) => {
+      process.stdout.write(JSON.stringify({ jsonrpc: '2.0', id: msg.id, result }) + '\n')
+    }
+    const respondError = (code, message) => {
+      process.stdout.write(
+        JSON.stringify({ jsonrpc: '2.0', id: msg.id, error: { code, message } }) + '\n',
+      )
+    }
+    if (msg.method === 'initialize') {
+      respond({
+        protocolVersion: '2024-11-05',
+        capabilities: { tools: {} },
+        serverInfo: { name: 'hermesoffice-docx-spike39', version: '0.0.1' },
+      })
+    } else if (msg.method === 'tools/list') {
+      respond({ tools: TOOLS })
+    } else if (msg.method === 'tools/call') {
+      try {
+        const r = await handleCall(msg.params.name, msg.params.arguments || {})
+        respond(r)
+      } catch (err) {
+        respondError(-32603, err instanceof Error ? err.message : String(err))
+      }
+    } else if (msg.method === 'ping') {
+      respond({})
+    } else if (msg.method === 'resources/list') {
+      respond({ resources: [] })
+    } else if (msg.method === 'notifications/initialized') {
+      // no-op
+    } else {
+      respondError(-32601, `method not found: ${msg.method}`)
+    }
+  }
+})

--- a/spikes/001-mcp-docx/server.mjs
+++ b/spikes/001-mcp-docx/server.mjs
@@ -27,14 +27,10 @@ import { createHash } from 'node:crypto'
 import { mkdirSync } from 'node:fs'
 import { dirname, join } from 'node:path'
 import { homedir } from 'node:os'
-import {
-  parseDocx,
-  saveDocx,
-} from '@hermesoffice/docx-engine'
+import { parseDocx, saveDocx } from '@hermesoffice/docx-engine'
 
 const DOCX_PATH = process.env.DOCX_PATH
-const AUDIT_DIR =
-  process.env.AUDIT_DIR || join(homedir(), '.hermesoffice-spike39-audit')
+const AUDIT_DIR = process.env.AUDIT_DIR || join(homedir(), '.hermesoffice-spike39-audit')
 
 if (!DOCX_PATH) {
   console.error('DOCX_PATH env var required')
@@ -65,7 +61,11 @@ function auditRecord(op) {
         id: `${id}-op1`,
         type: op.type,
         summary: op.summary,
-        scope: { kind: 'range', ref: `${op.startBlockIndex}..${op.endBlockIndex}`, label: `blocks ${op.startBlockIndex}-${op.endBlockIndex}` },
+        scope: {
+          kind: 'range',
+          ref: `${op.startBlockIndex}..${op.endBlockIndex}`,
+          label: `blocks ${op.startBlockIndex}-${op.endBlockIndex}`,
+        },
         payload: op.payload,
       },
     ],
@@ -96,8 +96,7 @@ function blockText(b) {
 }
 
 function blockLine(b, i) {
-  const prefix =
-    b.type === 'heading' ? `h${b.level || 1}` : b.type
+  const prefix = b.type === 'heading' ? `h${b.level || 1}` : b.type
   const content = blockText(b).slice(0, 200).replace(/\n/g, '⏎')
   return `${i}\t${prefix}\t${content}`
 }
@@ -110,7 +109,10 @@ function readBlocks(startBlockIndex, endBlockIndex) {
       const s = Number(startBlockIndex) || 0
       const e = Number(endBlockIndex) ?? blocks.length - 1
       if (s < 0 || e < s || e >= blocks.length) {
-        return { isError: true, output: `block index out of range (doc has ${blocks.length} visible blocks)` }
+        return {
+          isError: true,
+          output: `block index out of range (doc has ${blocks.length} visible blocks)`,
+        }
       }
       const lines = blocks.slice(s, e + 1).map(blockLine)
       return { isError: false, output: `visible blocks: ${blocks.length}\n${lines.join('\n')}` }
@@ -159,7 +161,10 @@ async function replaceBlocks(startBlockIndex, endBlockIndex, html) {
   const s = Number(startBlockIndex)
   const e = Number(endBlockIndex)
   if (!Number.isInteger(s) || !Number.isInteger(e) || s < 0 || e < s || e >= visible.length) {
-    return { isError: true, output: `block index out of range (doc has ${visible.length} visible blocks)` }
+    return {
+      isError: true,
+      output: `block index out of range (doc has ${visible.length} visible blocks)`,
+    }
   }
 
   // RFC 0008 gate: create the proposal record BEFORE mutating bytes
@@ -189,7 +194,8 @@ async function replaceBlocks(startBlockIndex, endBlockIndex, html) {
 const TOOLS = [
   {
     name: 'read_blocks',
-    description: 'Read the block tree of the .docx (index|type|content preview). Block indexes change after modifications; call again for fresh indexes.',
+    description:
+      'Read the block tree of the .docx (index|type|content preview). Block indexes change after modifications; call again for fresh indexes.',
     inputSchema: {
       type: 'object',
       properties: {
@@ -201,7 +207,8 @@ const TOOLS = [
   },
   {
     name: 'replace_blocks',
-    description: 'Replace a block range with new text. Runs through the Proposed Change pipeline (RFC 0008) with a stub auto-approve policy; the change is audited and the docx round-trip is byte-preserving.',
+    description:
+      'Replace a block range with new text. Runs through the Proposed Change pipeline (RFC 0008) with a stub auto-approve policy; the change is audited and the docx round-trip is byte-preserving.',
     inputSchema: {
       type: 'object',
       properties: {

--- a/spikes/001-mcp-docx/server.mjs
+++ b/spikes/001-mcp-docx/server.mjs
@@ -25,7 +25,7 @@
 import { readFile, writeFile } from 'node:fs/promises'
 import { createHash } from 'node:crypto'
 import { mkdirSync } from 'node:fs'
-import { dirname, join } from 'node:path'
+import { join } from 'node:path'
 import { homedir } from 'node:os'
 import { parseDocx, saveDocx } from '@hermesoffice/docx-engine'
 
@@ -107,7 +107,10 @@ function readBlocks(startBlockIndex, endBlockIndex) {
       const { parsed } = await loadParsed()
       const blocks = parsed.blocks.filter((b) => !b.hidden)
       const s = Number(startBlockIndex) || 0
-      const e = Number(endBlockIndex) ?? blocks.length - 1
+      const e =
+        endBlockIndex === undefined || endBlockIndex === null
+          ? blocks.length - 1
+          : Number(endBlockIndex)
       if (s < 0 || e < s || e >= blocks.length) {
         return {
           isError: true,


### PR DESCRIPTION
## Spike #39 — VALIDATED

**Pergunta:** as tools do painel de IA (`read_blocks` / `replace_blocks`) são reutilizáveis atrás de um transporte MCP, ou exigem redesenho do contexto (session-scoped, amarrado ao ProseMirror)?

## O que foi construído

`spikes/001-mcp-docx/` — servidor MCP stdio (JSON-RPC 2.0 manual, zero dependência) expondo as 2 tools **direto no docx-engine** (parse → block tree → saveDocx), com gate RFC 0008 (ProposedChangeRecord + stub auto-approve + audit log). Sem ProseMirror, sem renderer, sem sessão.

## Resultados

| Verificação | Resultado |
|---|---|
| Leitura da block tree real | ✅ 16 blocos, tipos corretos |
| Replace via MCP | ✅ re-read confirma edição |
| **Byte-preserving por parte zip** | ✅ partes intocadas bit-idênticas |
| RFC 0008 gate | ✅ audit log (`applied`, actor `agent`) |
| Fidelidade de formato | ✅ `rawPPr` preservado (h1 continua h1) |
| Edge case (range inválido) | ✅ erro limpo, sem mutation |
| **Cliente MCP real (Hermes CLI)** | ✅ `hermes mcp test` → 2 tools descobertas |

## Veredito

**VALIDATED** — o `docx-engine` é puro Node e request-scoped por natureza. O redesenho temido **não é necessário no nível do engine**. Nuance: as tools do painel operam no ProseMirror (renderer) — o transporte é reutilizável, os corpos precisam de um *twin headless* (engine-backed), ~150 linhas. **Custo: ~metade do estimado na issue.**

## Recomendação para o build real (Fase 2 keystone)

1. `packages/docx-mcp` com o twin headless + RFC 0008 via project-store
2. `@modelcontextprotocol/sdk` real (não JSON-RPC manual)
3. Compartilhar `parseHtmlFragment` (HTML restrito multi-bloco)
4. Conectar o modelo de aprovação (#38) ao ciclo de status

Detalhes completos: `spikes/001-mcp-docx/README.md`