### PR TITLE
fix(pdf): rebrand AI dock from Genspark to Hermes AI

### DIFF
--- a/apps/pdf/src/main/pdf-main.ts
+++ b/apps/pdf/src/main/pdf-main.ts
@@ -1350,12 +1350,12 @@ function registerPdfIpc(): void {
     async (_e, op: { prompt?: unknown; aspectRatio?: unknown }) => {
       if (!hasGskAuth())
         return {
-          error: 'Genspark account is not logged in on this machine; ask the user to log in first',
+          error: 'Hermes account is not logged in on this machine; ask the user to log in first',
         }
       if (!gskCloudToolsOn())
         return {
           error:
-            'Genspark cloud tools are turned off in Settings (AI Model); enable them to use this tool',
+            'Hermes cloud tools are turned off in Settings (AI Model); enable them to use this tool',
         }
       const prompt = String(op?.prompt ?? '').trim()
       if (!prompt) return { error: 'prompt must not be empty' }

--- a/apps/pdf/src/renderer/App.tsx
+++ b/apps/pdf/src/renderer/App.tsx
@@ -5,7 +5,7 @@ import type { CSSProperties, MouseEvent as ReactMouseEvent } from 'react'
 import { GlobalWorkerOptions, getDocument } from 'pdfjs-dist/legacy/build/pdf.mjs'
 import type { PDFDocumentProxy } from 'pdfjs-dist'
 import workerUrl from 'pdfjs-dist/legacy/build/pdf.worker.min.mjs?url'
-import { AiPanel, GensparkMark } from './ai/AiPanel'
+import { AiPanel, HermesMark } from './ai/AiPanel'
 import { AiAskPopover, type AskAnchorRect } from './AiAskPopover'
 import { loadSavedAnnots } from './annotation-catalog'
 import {
@@ -5715,7 +5715,7 @@ export default function App() {
         <div className="ribbon-body">
           {ribbonTab === 'home' && (
             <>
-              {/* ---- Genspark AI (first slot: entry + one-click AI actions, docs parity) ---- */}
+              {/* ---- Hermes AI (first slot: entry + one-click AI actions, docs parity) ---- */}
               <div className="ribbon-group">
                 <div className="ribbon-group-items">
                   <button
@@ -5724,9 +5724,9 @@ export default function App() {
                     onClick={() => setAiCollapsed((v) => !v)}
                   >
                     <span className="rb-big-icon">
-                      <GensparkMark size={26} />
+                      <HermesMark size={26} />
                     </span>
-                    <span>Genspark AI</span>
+                    <span>Hermes AI</span>
                   </button>
                   <button
                     className="rb-big ai-entry"
@@ -5866,7 +5866,7 @@ export default function App() {
                   >
                     <span className="rb-big-icon">
                       <span className="ai-feature-icon" aria-hidden="true">
-                        <GensparkMark size={20} />
+                        <HermesMark size={20} />
                       </span>
                     </span>
                     <span>{t('aiProcessNotesBtn')}</span>
@@ -6013,7 +6013,7 @@ export default function App() {
                   >
                     <span className="rb-big-icon">
                       <span className="ai-feature-icon" aria-hidden="true">
-                        <GensparkMark size={20} />
+                        <HermesMark size={20} />
                       </span>
                     </span>
                     <span>{t('aiFillFormBtn')}</span>
@@ -6342,7 +6342,7 @@ export default function App() {
               aria-label={t('aiOpenAssistant')}
               onClick={() => setAiCollapsed(false)}
             >
-              <GensparkMark size={22} />
+              <HermesMark size={22} />
             </button>
           )}
           <AiPanel

--- a/apps/pdf/src/renderer/ai/AiPanel.tsx
+++ b/apps/pdf/src/renderer/ai/AiPanel.tsx
@@ -532,12 +532,12 @@ export function AiPanel({
         onPointerDown={startResize}
         role="separator"
         aria-orientation="vertical"
-        aria-label="Genspark"
+        aria-label="Hermes AI"
       />
       <header className="ai-panel-header">
         <span className="ai-panel-title">
-          <GensparkMark size={22} />
-          Genspark
+          <HermesMark size={22} />
+          Hermes AI
         </span>
         <div className="ai-panel-header-actions">
           {chat.length > 0 && (
@@ -880,9 +880,9 @@ function IconCollapse(): ReactElement {
   )
 }
 
-/** Genspark brand mark (rounded-square sparkle badge), inline so it renders
+/** Hermes brand mark (rounded-square sparkle badge), inline so it renders
  * crisply at device resolution instead of going through <img> rasterization */
-export function GensparkMark({ size = 18 }: { size?: number }): React.JSX.Element {
+export function HermesMark({ size = 18 }: { size?: number }): React.JSX.Element {
   return (
     <svg
       width={size}

--- a/apps/pdf/src/renderer/ai/pdf-skill.ts
+++ b/apps/pdf/src/renderer/ai/pdf-skill.ts
@@ -33,7 +33,7 @@ const SYSTEM_PROMPT = `You are HermesOffice's PDF assistant, helping the user re
 const SELECTION_CONTEXT_CHARS = 12_000
 
 const GSK_TOOLS_OFF_NOTE =
-  '\n\nNote: generate_image is currently unavailable (Genspark cloud tools are off or the user is signed out). Do not call or promise it; use image_search for imagery.'
+  '\n\nNote: generate_image is currently unavailable (Hermes cloud tools are off or the user is signed out). Do not call or promise it; use image_search for imagery.'
 
 export function createPdfSkill(deps: PdfAiDeps): AgentSkill {
   return {

--- a/apps/pdf/src/renderer/ai/tools.ts
+++ b/apps/pdf/src/renderer/ai/tools.ts
@@ -103,7 +103,7 @@ export interface PdfAiDeps {
   /** Queue a pending delete of an existing image */
   deleteImage(ref: PageImageRef): void
   searchImages(query: string, maxResults: number): Promise<ImageSearchResponse>
-  /** live predicate: gsk login && the Genspark-cloud-tools toggle; false hides generate_image */
+  /** live predicate: gsk login && the Hermes-cloud-tools toggle; false hides generate_image */
   gskTools?(): boolean
   generateImage(op: { prompt: string; aspectRatio?: string }): Promise<{
     url?: string

--- a/apps/pdf/src/renderer/i18n/strings.ts
+++ b/apps/pdf/src/renderer/i18n/strings.ts
@@ -252,7 +252,7 @@ export const strings = {
     aiTimeoutError: 'AI 请求超时：网络长时间无响应，已停止。请检查网络后重试',
     aiOverloadedError: 'AI 服务当前繁忙，请稍后重试',
     aiNetworkError: '网络有问题，无法连接 AI 服务。请检查网络后重试',
-    aiCreditsExhausted: 'Genspark 积分已用完，请前往 genspark.ai/pricing 充值后重试',
+    aiCreditsExhausted: 'Hermes 积分已用完，请前往 genspark.ai/pricing 充值后重试',
     aiToolReadPages: '读取第 {start}-{end} 页',
     aiToolSearch: '搜索"{query}"（{count} 处）',
     aiToolGoto: '跳转到第 {page} 页',
@@ -371,7 +371,7 @@ export const strings = {
     removeStamp: '点击选中此水印/页眉页脚',
     props: '属性',
     propsTitle: '文档属性',
-    ribbonAiAssistant: 'Genspark',
+    ribbonAiAssistant: 'Hermes AI',
     ribbonAiAssistantTip: '打开 AI 助手',
     propTitle: '标题',
     propAuthor: '作者',
@@ -528,7 +528,7 @@ export const strings = {
     aiNetworkError:
       'Network problem: could not reach the AI service. Check your connection and try again',
     aiCreditsExhausted:
-      'Your Genspark credits have run out. Visit genspark.ai/pricing to top up, then try again',
+      'Your Hermes credits have run out. Visit genspark.ai/pricing to top up, then try again',
     aiToolReadPages: 'Read pages {start}-{end}',
     aiToolSearch: 'Search "{query}" ({count} hits)',
     aiToolGoto: 'Go to page {page}',
@@ -649,7 +649,7 @@ export const strings = {
     removeStamp: 'Click to select this watermark / header / footer',
     props: 'Properties',
     propsTitle: 'Document properties',
-    ribbonAiAssistant: 'Genspark',
+    ribbonAiAssistant: 'Hermes AI',
     ribbonAiAssistantTip: 'Open the AI assistant',
     propTitle: 'Title',
     propAuthor: 'Author',
@@ -805,7 +805,7 @@ export const strings = {
     aiNetworkError:
       'ネットワークに問題があり、AI サービスに接続できません。接続を確認して再試行してください',
     aiCreditsExhausted:
-      'Gensparkクレジットを使い切りました。genspark.ai/pricing でチャージしてから再試行してください',
+      'Hermesクレジットを使い切りました。genspark.ai/pricing でチャージしてから再試行してください',
     aiToolReadPages: 'ページ {start}-{end} を読む',
     aiToolSearch: '「{query}」を検索（{count} 件）',
     aiToolGoto: 'ページ {page} へ移動',
@@ -926,7 +926,7 @@ export const strings = {
     removeStamp: 'クリックでこの透かし/ヘッダーを選択',
     props: 'プロパティ',
     propsTitle: '文書のプロパティ',
-    ribbonAiAssistant: 'Genspark',
+    ribbonAiAssistant: 'Hermes AI',
     ribbonAiAssistantTip: 'AI アシスタントを開く',
     propTitle: 'タイトル',
     propAuthor: '作成者',
@@ -1083,7 +1083,7 @@ export const strings = {
     aiNetworkError:
       '네트워크에 문제가 있어 AI 서비스에 연결할 수 없습니다. 연결을 확인한 후 다시 시도해 주세요',
     aiCreditsExhausted:
-      'Genspark 크레딧을 모두 사용했습니다. genspark.ai/pricing에서 충전한 후 다시 시도해 주세요',
+      'Hermes 크레딧을 모두 사용했습니다. genspark.ai/pricing에서 충전한 후 다시 시도해 주세요',
     aiToolReadPages: '{start}-{end}쪽 읽기',
     aiToolSearch: '"{query}" 검색 ({count}건)',
     aiToolGoto: '{page}쪽으로 이동',
@@ -1203,7 +1203,7 @@ export const strings = {
     removeStamp: '클릭하여 이 워터마크/머리글 선택',
     props: '속성',
     propsTitle: '문서 속성',
-    ribbonAiAssistant: 'Genspark',
+    ribbonAiAssistant: 'Hermes AI',
     ribbonAiAssistantTip: 'AI 도우미 열기',
     propTitle: '제목',
     propAuthor: '작성자',
@@ -1363,7 +1363,7 @@ export const strings = {
     aiNetworkError:
       'Problème réseau : impossible de joindre le service IA. Vérifiez votre connexion et réessayez',
     aiCreditsExhausted:
-      'Vos crédits Genspark sont épuisés. Rechargez sur genspark.ai/pricing puis réessayez',
+      'Vos crédits Hermes sont épuisés. Rechargez sur genspark.ai/pricing puis réessayez',
     aiToolReadPages: 'Lire les pages {start}-{end}',
     aiToolSearch: 'Rechercher « {query} » ({count} occurrences)',
     aiToolGoto: 'Aller à la page {page}',
@@ -1486,7 +1486,7 @@ export const strings = {
     removeStamp: 'Cliquer pour sélectionner ce filigrane / en-tête',
     props: 'Propriétés',
     propsTitle: 'Propriétés du document',
-    ribbonAiAssistant: 'Genspark',
+    ribbonAiAssistant: 'Hermes AI',
     ribbonAiAssistantTip: "Ouvrir l'assistant IA",
     propTitle: 'Titre',
     propAuthor: 'Auteur',
@@ -1645,7 +1645,7 @@ export const strings = {
     aiNetworkError:
       'Netzwerkproblem: Der KI-Dienst ist nicht erreichbar. Prüfe deine Verbindung und versuche es erneut',
     aiCreditsExhausted:
-      'Deine Genspark-Credits sind aufgebraucht. Lade unter genspark.ai/pricing auf und versuche es erneut',
+      'Deine Hermes-Credits sind aufgebraucht. Lade unter genspark.ai/pricing auf und versuche es erneut',
     aiToolReadPages: 'Seiten {start}-{end} lesen',
     aiToolSearch: '„{query}" suchen ({count} Treffer)',
     aiToolGoto: 'Zu Seite {page} springen',
@@ -1767,7 +1767,7 @@ export const strings = {
     removeStamp: 'Klicken, um dieses Wasserzeichen / diese Kopfzeile auszuwählen',
     props: 'Eigenschaften',
     propsTitle: 'Dokumenteigenschaften',
-    ribbonAiAssistant: 'Genspark',
+    ribbonAiAssistant: 'Hermes AI',
     ribbonAiAssistantTip: 'KI-Assistenten öffnen',
     propTitle: 'Titel',
     propAuthor: 'Autor',
@@ -1926,7 +1926,7 @@ export const strings = {
     aiNetworkError:
       'Problema de red: no se pudo conectar con el servicio de IA. Comprueba tu conexión e inténtalo de nuevo',
     aiCreditsExhausted:
-      'Tus créditos de Genspark se han agotado. Recarga en genspark.ai/pricing e inténtalo de nuevo',
+      'Tus créditos de Hermes se han agotado. Recarga en genspark.ai/pricing e inténtalo de nuevo',
     aiToolReadPages: 'Leer páginas {start}-{end}',
     aiToolSearch: 'Buscar «{query}» ({count} resultados)',
     aiToolGoto: 'Ir a la página {page}',
@@ -2049,7 +2049,7 @@ export const strings = {
     removeStamp: 'Haz clic para seleccionar esta marca de agua / encabezado',
     props: 'Propiedades',
     propsTitle: 'Propiedades del documento',
-    ribbonAiAssistant: 'Genspark',
+    ribbonAiAssistant: 'Hermes AI',
     ribbonAiAssistantTip: 'Abrir el asistente de IA',
     propTitle: 'Título',
     propAuthor: 'Autor',
@@ -2206,7 +2206,7 @@ export const strings = {
     aiNetworkError:
       'เครือข่ายมีปัญหา ไม่สามารถเชื่อมต่อบริการ AI ได้ โปรดตรวจสอบการเชื่อมต่อแล้วลองใหม่',
     aiCreditsExhausted:
-      'เครดิต Genspark ของคุณหมดแล้ว โปรดเติมเครดิตที่ genspark.ai/pricing แล้วลองใหม่',
+      'เครดิต Hermes ของคุณหมดแล้ว โปรดเติมเครดิตที่ genspark.ai/pricing แล้วลองใหม่',
     aiToolReadPages: 'อ่านหน้า {start}-{end}',
     aiToolSearch: 'ค้นหา "{query}" ({count} แห่ง)',
     aiToolGoto: 'ไปที่หน้า {page}',
@@ -2326,7 +2326,7 @@ export const strings = {
     removeStamp: 'คลิกเพื่อเลือกลายน้ำ/หัวท้ายนี้',
     props: 'คุณสมบัติ',
     propsTitle: 'คุณสมบัติเอกสาร',
-    ribbonAiAssistant: 'Genspark',
+    ribbonAiAssistant: 'Hermes AI',
     ribbonAiAssistantTip: 'เปิดผู้ช่วย AI',
     propTitle: 'ชื่อเรื่อง',
     propAuthor: 'ผู้เขียน',
@@ -2484,7 +2484,7 @@ export const strings = {
     aiNetworkError:
       'Masalah jaringan: tidak dapat terhubung ke layanan AI. Periksa koneksi Anda lalu coba lagi',
     aiCreditsExhausted:
-      'Kredit Genspark Anda telah habis. Isi ulang di genspark.ai/pricing lalu coba lagi',
+      'Kredit Hermes Anda telah habis. Isi ulang di genspark.ai/pricing lalu coba lagi',
     aiToolReadPages: 'Baca halaman {start}-{end}',
     aiToolSearch: 'Cari "{query}" ({count} temuan)',
     aiToolGoto: 'Ke halaman {page}',
@@ -2606,7 +2606,7 @@ export const strings = {
     removeStamp: 'Klik untuk memilih tanda air / header ini',
     props: 'Properti',
     propsTitle: 'Properti dokumen',
-    ribbonAiAssistant: 'Genspark',
+    ribbonAiAssistant: 'Hermes AI',
     ribbonAiAssistantTip: 'Buka asisten AI',
     propTitle: 'Judul',
     propAuthor: 'Penulis',
@@ -2764,7 +2764,7 @@ export const strings = {
     aiNetworkError:
       'Проблема с сетью: не удалось подключиться к сервису ИИ. Проверьте подключение и повторите попытку',
     aiCreditsExhausted:
-      'Кредиты Genspark исчерпаны. Пополните баланс на genspark.ai/pricing и повторите попытку',
+      'Кредиты Hermes исчерпаны. Пополните баланс на genspark.ai/pricing и повторите попытку',
     aiToolReadPages: 'Чтение страниц {start}-{end}',
     aiToolSearch: 'Поиск «{query}» ({count} совпадений)',
     aiToolGoto: 'Перейти на страницу {page}',
@@ -2887,7 +2887,7 @@ export const strings = {
     removeStamp: 'Нажмите, чтобы выбрать этот знак / колонтитул',
     props: 'Свойства',
     propsTitle: 'Свойства документа',
-    ribbonAiAssistant: 'Genspark',
+    ribbonAiAssistant: 'Hermes AI',
     ribbonAiAssistantTip: 'Открыть помощника ИИ',
     propTitle: 'Заголовок',
     propAuthor: 'Автор',
@@ -3043,7 +3043,7 @@ export const strings = {
     aiNetworkError:
       'مشكلة في الشبكة: تعذّر الوصول إلى خدمة الذكاء الاصطناعي. تحقق من الاتصال وحاول مجددًا',
     aiCreditsExhausted:
-      'نفدت أرصدة Genspark لديك. يرجى إعادة الشحن عبر genspark.ai/pricing ثم المحاولة مجددًا',
+      'نفدت أرصدة Hermes لديك. يرجى إعادة الشحن عبر genspark.ai/pricing ثم المحاولة مجددًا',
     aiToolReadPages: 'قراءة الصفحات {start}-{end}',
     aiToolSearch: 'بحث عن "{query}" ({count} نتيجة)',
     aiToolGoto: 'الانتقال إلى الصفحة {page}',
@@ -3163,7 +3163,7 @@ export const strings = {
     removeStamp: 'انقر لتحديد هذه العلامة/الرأس',
     props: 'الخصائص',
     propsTitle: 'خصائص المستند',
-    ribbonAiAssistant: 'Genspark',
+    ribbonAiAssistant: 'Hermes AI',
     ribbonAiAssistantTip: 'فتح مساعد الذكاء الاصطناعي',
     propTitle: 'العنوان',
     propAuthor: 'المؤلف',
@@ -3322,7 +3322,7 @@ export const strings = {
     aiNetworkError:
       'Problema de rede: não foi possível conectar ao serviço de IA. Verifique sua conexão e tente novamente',
     aiCreditsExhausted:
-      'Seus créditos Genspark acabaram. Recarregue em genspark.ai/pricing e tente novamente',
+      'Seus créditos Hermes acabaram. Recarregue em genspark.ai/pricing e tente novamente',
     aiToolReadPages: 'Ler páginas {start}-{end}',
     aiToolSearch: 'Pesquisar "{query}" ({count} ocorrências)',
     aiToolGoto: 'Ir para a página {page}',
@@ -3444,7 +3444,7 @@ export const strings = {
     removeStamp: "Clique para selecionar esta marca d'água / cabeçalho",
     props: 'Propriedades',
     propsTitle: 'Propriedades do documento',
-    ribbonAiAssistant: 'Genspark',
+    ribbonAiAssistant: 'Hermes AI',
     ribbonAiAssistantTip: 'Abrir o assistente de IA',
     propTitle: 'Título',
     propAuthor: 'Autor',
@@ -3603,7 +3603,7 @@ export const strings = {
     aiNetworkError:
       'Problema di rete: impossibile raggiungere il servizio IA. Controlla la connessione e riprova',
     aiCreditsExhausted:
-      'I tuoi crediti Genspark sono esauriti. Ricarica su genspark.ai/pricing e riprova',
+      'I tuoi crediti Hermes sono esauriti. Ricarica su genspark.ai/pricing e riprova',
     aiToolReadPages: 'Leggi le pagine {start}-{end}',
     aiToolSearch: 'Cerca "{query}" ({count} risultati)',
     aiToolGoto: 'Vai alla pagina {page}',
@@ -3727,7 +3727,7 @@ export const strings = {
     removeStamp: 'Fai clic per selezionare questa filigrana / intestazione',
     props: 'Proprietà',
     propsTitle: 'Proprietà del documento',
-    ribbonAiAssistant: 'Genspark',
+    ribbonAiAssistant: 'Hermes AI',
     ribbonAiAssistantTip: "Apri l'assistente IA",
     propTitle: 'Titolo',
     propAuthor: 'Autore',
@@ -3885,7 +3885,7 @@ export const strings = {
     aiNetworkError:
       'Problem z siecią: nie można połączyć się z usługą AI. Sprawdź połączenie i spróbuj ponownie',
     aiCreditsExhausted:
-      'Twoje kredyty Genspark wyczerpały się. Doładuj konto na genspark.ai/pricing i spróbuj ponownie',
+      'Twoje kredyty Hermes wyczerpały się. Doładuj konto na genspark.ai/pricing i spróbuj ponownie',
     aiToolReadPages: 'Czytaj strony {start}-{end}',
     aiToolSearch: 'Szukaj „{query}" ({count} wyników)',
     aiToolGoto: 'Przejdź do strony {page}',
@@ -4008,7 +4008,7 @@ export const strings = {
     removeStamp: 'Kliknij, aby zaznaczyć ten znak wodny / nagłówek',
     props: 'Właściwości',
     propsTitle: 'Właściwości dokumentu',
-    ribbonAiAssistant: 'Genspark',
+    ribbonAiAssistant: 'Hermes AI',
     ribbonAiAssistantTip: 'Otwórz asystenta AI',
     propTitle: 'Tytuł',
     propAuthor: 'Autor',
@@ -4167,7 +4167,7 @@ export const strings = {
     aiNetworkError:
       'Netwerkprobleem: kan de AI-service niet bereiken. Controleer je verbinding en probeer het opnieuw',
     aiCreditsExhausted:
-      'Je Genspark-credits zijn op. Waardeer op via genspark.ai/pricing en probeer het opnieuw',
+      'Je Hermes-credits zijn op. Waardeer op via genspark.ai/pricing en probeer het opnieuw',
     aiToolReadPages: "Pagina's {start}-{end} lezen",
     aiToolSearch: 'Zoeken naar "{query}" ({count} resultaten)',
     aiToolGoto: 'Ga naar pagina {page}',
@@ -4289,7 +4289,7 @@ export const strings = {
     removeStamp: 'Klik om dit watermerk / deze koptekst te selecteren',
     props: 'Eigenschappen',
     propsTitle: 'Documenteigenschappen',
-    ribbonAiAssistant: 'Genspark',
+    ribbonAiAssistant: 'Hermes AI',
     ribbonAiAssistantTip: 'De AI-assistent openen',
     propTitle: 'Titel',
     propAuthor: 'Auteur',
@@ -4447,7 +4447,7 @@ export const strings = {
     aiNetworkError:
       'Masalah rangkaian: tidak dapat menghubungi perkhidmatan AI. Semak sambungan anda dan cuba lagi',
     aiCreditsExhausted:
-      'Kredit Genspark anda telah habis. Tambah nilai di genspark.ai/pricing dan cuba lagi',
+      'Kredit Hermes anda telah habis. Tambah nilai di genspark.ai/pricing dan cuba lagi',
     aiToolReadPages: 'Baca halaman {start}-{end}',
     aiToolSearch: 'Cari "{query}" ({count} padanan)',
     aiToolGoto: 'Pergi ke halaman {page}',
@@ -4569,7 +4569,7 @@ export const strings = {
     removeStamp: 'Klik untuk memilih tera air / pengepala ini',
     props: 'Sifat',
     propsTitle: 'Sifat dokumen',
-    ribbonAiAssistant: 'Genspark',
+    ribbonAiAssistant: 'Hermes AI',
     ribbonAiAssistantTip: 'Buka pembantu AI',
     propTitle: 'Tajuk',
     propAuthor: 'Pengarang',
@@ -4722,7 +4722,7 @@ export const strings = {
     aiTimeoutError: 'תם הזמן לבקשת ה-AI: אין תגובה מהרשת וההרצה הופסקה. בדוק את החיבור ונסה שוב',
     aiOverloadedError: 'שירות ה-AI עמוס כרגע — נסו שוב בעוד רגע',
     aiNetworkError: 'בעיית רשת: לא ניתן להתחבר לשירות ה-AI. בדוק את החיבור ונסה שוב',
-    aiCreditsExhausted: 'קרדיטי Genspark שלך אזלו. טען מחדש ב-genspark.ai/pricing ונסה שוב',
+    aiCreditsExhausted: 'קרדיטי Hermes שלך אזלו. טען מחדש ב-genspark.ai/pricing ונסה שוב',
     aiToolReadPages: 'קריאת עמודים {start}-{end}',
     aiToolSearch: 'חיפוש "{query}" ({count} תוצאות)',
     aiToolGoto: 'מעבר לעמוד {page}',
@@ -4842,7 +4842,7 @@ export const strings = {
     removeStamp: 'לחצו לבחירת סימן המים/הכותרת הזו',
     props: 'מאפיינים',
     propsTitle: 'מאפייני המסמך',
-    ribbonAiAssistant: 'Genspark',
+    ribbonAiAssistant: 'Hermes AI',
     ribbonAiAssistantTip: 'פתח את עוזר ה-AI',
     propTitle: 'כותרת',
     propAuthor: 'מחבר',
@@ -4999,7 +4999,7 @@ export const strings = {
     aiNetworkError:
       'नेटवर्क समस्या: AI सेवा से कनेक्ट नहीं हो सका। कनेक्शन जांचें और फिर से प्रयास करें',
     aiCreditsExhausted:
-      'आपके Genspark क्रेडिट समाप्त हो गए हैं। genspark.ai/pricing पर रिचार्ज करें और फिर से प्रयास करें',
+      'आपके Hermes क्रेडिट समाप्त हो गए हैं। genspark.ai/pricing पर रिचार्ज करें और फिर से प्रयास करें',
     aiToolReadPages: 'पृष्ठ {start}-{end} पढ़ें',
     aiToolSearch: '"{query}" खोजें ({count} परिणाम)',
     aiToolGoto: 'पृष्ठ {page} पर जाएँ',
@@ -5120,7 +5120,7 @@ export const strings = {
     removeStamp: 'इस वॉटरमार्क/शीर्षलेख-पादलेख को चुनने के लिए क्लिक करें',
     props: 'गुण',
     propsTitle: 'दस्तावेज़ गुण',
-    ribbonAiAssistant: 'Genspark',
+    ribbonAiAssistant: 'Hermes AI',
     ribbonAiAssistantTip: 'AI सहायक खोलें',
     propTitle: 'शीर्षक',
     propAuthor: 'लेखक',
@@ -5273,7 +5273,7 @@ export const strings = {
     aiTimeoutError: 'AI 請求逾時：網路長時間無回應，已停止。請檢查網路後重試',
     aiOverloadedError: 'AI 服務目前繁忙，請稍後重試',
     aiNetworkError: '網路有問題，無法連接 AI 服務。請檢查網路後重試',
-    aiCreditsExhausted: 'Genspark 點數已用完，請前往 genspark.ai/pricing 儲值後重試',
+    aiCreditsExhausted: 'Hermes 點數已用完，請前往 genspark.ai/pricing 儲值後重試',
     aiToolReadPages: '讀取第 {start}-{end} 頁',
     aiToolSearch: '搜尋「{query}」（{count} 處）',
     aiToolGoto: '跳至第 {page} 頁',
@@ -5392,7 +5392,7 @@ export const strings = {
     removeStamp: '點一下選取此浮水印/頁首頁尾',
     props: '屬性',
     propsTitle: '文件屬性',
-    ribbonAiAssistant: 'Genspark',
+    ribbonAiAssistant: 'Hermes AI',
     ribbonAiAssistantTip: '開啟 AI 助理',
     propTitle: '標題',
     propAuthor: '作者',

--- a/apps/pdf/src/renderer/styles.css
+++ b/apps/pdf/src/renderer/styles.css
@@ -1145,7 +1145,7 @@ button {
 
 /* ── Encrypted document password ── */
 
-/* ---- encrypted-PDF password dialog (Genspark DS form dialog, matching the
+/* ---- encrypted-PDF password dialog (Hermes DS form dialog, matching the
    docs PasswordDialog and mockups/protect-dialogs-genspark.html §1/2) ---- */
 
 /* base .pdf-modal-mask (defined below) top-aligns dialogs; this one centers */
@@ -1416,7 +1416,7 @@ button {
   gap: 8px;
 }
 
-/* Genspark DS modal footer buttons: secondary = bg-subtle, primary = black (#232425) */
+/* Hermes DS modal footer buttons: secondary = bg-subtle, primary = black (#232425) */
 .pdf-modal-btn {
   display: inline-flex;
   align-items: center;
@@ -3291,15 +3291,15 @@ button {
   white-space: nowrap;
 }
 
-/* Genspark brand logo (shared by the collapsed entry and the AI panel title) */
-.genspark-badge {
+/* Hermes brand logo (shared by the collapsed entry and the AI panel title) */
+.hermes-badge {
   display: block;
   width: 22px;
   height: 22px;
   border-radius: 50%;
 }
 
-.ai-panel-title .genspark-badge {
+.ai-panel-title .hermes-badge {
   width: 18px;
   height: 18px;
 }

--- a/apps/pdf/src/shared/ipc.ts
+++ b/apps/pdf/src/shared/ipc.ts
@@ -727,7 +727,7 @@ export interface PdfApi {
   imageSearch(query: string, maxResults?: number): Promise<ImageSearchResponse>
   /** Download an image URL in the main process (SSRF-guarded, avoids CORS); null on failure */
   fetchImage(url: string): Promise<{ base64: string; mime: string } | null>
-  /** AI image generation via Genspark (gsk); returns a downloadable URL or an error message */
+  /** AI image generation via Hermes (gsk); returns a downloadable URL or an error message */
   generateImage(op: { prompt: string; aspectRatio?: string }): Promise<{
     url?: string
     error?: string
@@ -760,7 +760,7 @@ export interface PdfApi {
    *  clicks produce no DOM event here) — dismiss open popovers */
   onChromePressed(handler: () => void): () => void
   getAiSettings(): Promise<AiSettings>
-  /** Genspark login state (gsk); gates the cloud-only generate_image tool */
+  /** Hermes login state (gsk); gates the cloud-only generate_image tool */
   gskStatus(): Promise<{ loggedIn: boolean }>
   aiStream(request: AiStreamRequest): Promise<void>
   aiStreamCancel(requestId: string): Promise<void>


### PR DESCRIPTION
## Summary

Replace all user-visible **Genspark** branding in the PDF app's AI dock with **Hermes AI**, matching the pattern already established in Docs, Sheets, and Slides.

Fixes #54

## Changes

| Area | Before | After |
|------|--------|-------|
| AI panel header (expanded) | Genspark | Hermes AI |
| Ribbon button (collapsed) | Genspark AI | Hermes AI |
| `ribbonAiAssistant` i18n (19 languages) | Genspark | Hermes AI |
| `aiCreditsExhausted` i18n (19 languages) | Genspark credits | Hermes credits |
| Main-process error messages | Genspark account/cloud tools | Hermes |
| AI system prompt note | Genspark cloud tools | Hermes cloud tools |
| Component name | `GensparkMark` | `HermesMark` |
| CSS class | `.genspark-badge` | `.hermes-badge` |

## Not changed (intentional)

- `genspark.ai/pricing` URLs — these are live links to the pricing page
- GitHub issue references in comments (`genspark-ai/hermesoffice#55`)
- Mockup file path references in comments
- IPC channel names — renaming would break running sessions
- Other apps (Docs/Sheets/Slides) — out of scope per issue #54
- `ee/` directory — out of scope

## Verification

- `npm run test -w @hermesoffice/pdf` — **575 tests pass (42 files)**
- `npm run typecheck -w @hermesoffice/pdf` — clean
- `npm run check:theme-colors` — clean
- Grep zero on user-visible Genspark strings in `apps/pdf`